### PR TITLE
Button/TextEdit Styling

### DIFF
--- a/src/qt/res/css/Dark.css
+++ b/src/qt/res/css/Dark.css
@@ -216,6 +216,7 @@ QMenuBar::item:selected,
 QMenu::item:selected,
 QTextEdit:focus {
   border-width: 4px;
+  padding: 1px;
   background: #31398c;
 }
 
@@ -252,10 +253,11 @@ QPushButton:hover {
 }
 
 QPushButton:pressed {
-  background-color: #5e0057;
+  background-color: #1e223a;
   border-style: solid;
   border-color: #4e0049;
-  border-width: 10px;
+  padding: 0px 0px;
+  border-width: 9px;
 }
 
 QPushButton#btn_rescan{
@@ -273,6 +275,12 @@ QPushButton#btnLockUnlock{
   background-color: transparent;
   border: 0;
   border-radius: 0;
+}
+
+QPushButton#pushButtonBackup{
+  width: 200px;
+  height: 30px;
+  border: 5px solid red;
 }
 
 /*** Spin Boxes, Combo Boxes ***/

--- a/src/qt/res/css/Light.css
+++ b/src/qt/res/css/Light.css
@@ -178,6 +178,7 @@ QMenuBar::item:selected,
 QMenu::item:selected,
 QTextEdit:focus {
   border-width: 4px;
+  padding: 1px;
   background: #a7a7a7;
 }
 
@@ -222,7 +223,8 @@ QPushButton:hover {
 }
 
 QPushButton:pressed {
-  background-color: #a975a5;
+  background-color: #f7f7f7;
+  padding: 0px 0px;
   border-style: solid;
   border-color: #b57fb1;
   border-width: 10px;
@@ -252,6 +254,12 @@ QPushButton#btnLockUnlock{
   background-color: transparent;
   border: 0;
   border-radius: 0;
+}
+
+QPushButton#pushButtonBackup{
+  width: 200px;
+  height: 30px;
+  border: 5 solid red;
 }
 
 /*** Spin Boxes, Combo Boxes ***/


### PR DESCRIPTION
QLineEdit:focus - no longer cuts off text when focused

QPushButton:pressed - no longer cuts off text when pressed. Background color matched to theme

Backup Button Styling - No longer cuts off text. Larger size. Red border when wallet has not been backed up