### PR TITLE
Various Minor Updates

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -340,7 +340,7 @@ bool CActiveMasternode::GetMasterNodeVin(CTxIn& vin, CPubKey& pubkey, CKey& secr
     TRY_LOCK(pwalletMain->cs_wallet, fWallet);
     if (!fWallet) return false;
 
-    vector<COutput> possibleCoins = SelectCoinsMasternode();
+    std::vector<COutput> possibleCoins = SelectCoinsMasternode();
     COutput* selectedOutput;
 
     // Find the vin
@@ -465,9 +465,9 @@ bool CActiveMasternode::GetVinFromOutput(COutput out, CTxIn& vin, CPubKey& pubke
 // get all possible outputs for running Masternode
 vector<COutput> CActiveMasternode::SelectCoinsMasternode()
 {
-    vector<COutput> vCoins;
-    vector<COutput> filteredCoins;
-    vector<COutPoint> confLockedCoins;
+    std::vector<COutput> vCoins;
+    std::vector<COutput> filteredCoins;
+    std::vector<COutPoint> confLockedCoins;
 
     // Temporary unlock MN coins from masternode.conf
     if (GetBoolArg("-mnconflock", true)) {

--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -64,7 +64,7 @@ public:
 
     /// Get 1000000 DAPS input that can be used for the Masternode
     bool GetMasterNodeVin(CTxIn& vin, CPubKey& pubkey, CKey& secretKey);
-    vector<COutput> SelectCoinsMasternode();
+    std::vector<COutput> SelectCoinsMasternode();
 
     /// Enable cold wallet mode (run a Masternode with no funds)
     bool EnableHotColdMasterNode(CTxIn& vin, CService& addr);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1846,12 +1846,12 @@ bool AppInit2(bool isDaemon)
         //read decoy confirmation min
         pwalletMain->DecoyConfirmationMinimum = GetArg("-decoyconfirm", 15);
     }
-#endif
 
     CWalletDB walletdb(strWalletFile);
     double reserveBalance;
     if (walletdb.ReadReserveAmount(reserveBalance))
         nReserveBalance = reserveBalance * COIN;
+#endif
 
     return !fRequestShutdown;
 }

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -305,7 +305,7 @@ bool CheckStakeKernelHash(unsigned int nBits, const CBlockHeader blockFrom, cons
     unsigned int nTimeBlockFrom = blockFrom.GetBlockTime();
 
     if (nTimeTx < nTimeBlockFrom) // Transaction timestamp violation
-        return error("CheckStakeKernelHash() : nTime violation");
+        return false;
 
     if (nTimeBlockFrom + nStakeMinAge > nTimeTx) // Min age requirement
         return false;
@@ -348,8 +348,6 @@ bool CheckStakeKernelHash(unsigned int nBits, const CBlockHeader blockFrom, cons
 
         // if stake hash does not meet the target then continue to next iteration
         if (!stakeTargetHit(hashProofOfStake, nValueIn, bnTargetPerCoinDay)) {
-        	if (fDebug)
-        		LogPrintf("CheckStakeKernelHash() : staking not found, you're not lucky enough\n");
             continue;
         }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -61,6 +61,7 @@ public:
 uint64_t nLastBlockTx = 0;
 uint64_t nLastBlockSize = 0;
 int64_t nLastCoinStakeSearchInterval = 0;
+int64_t nDefaultMinerSleep = 0;
 //int64_t nConsolidationTime = 0;
 
 // We want to sort transactions by priority and fee rate, so:
@@ -642,7 +643,8 @@ bool fGenerateDapscoins = false;
 
 void BitcoinMiner(CWallet* pwallet, bool fProofOfStake, MineType mineType)
 {
-    LogPrintf("DAPScoinMiner started\n");
+    nDefaultMinerSleep = GetArg("-minersleep", 30000);
+    LogPrintf("DAPScoinMiner started with %sms sleep time\n", nDefaultMinerSleep);
     SetThreadPriority(THREAD_PRIORITY_LOWEST);
     RenameThread("dapscoin-miner");
     fGenerateDapscoins = true;
@@ -701,6 +703,7 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake, MineType mineType)
             }
             
         }
+        MilliSleep(nDefaultMinerSleep);
         //
         // Create new block
         //

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -668,7 +668,7 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake, MineType mineType)
                 continue;
             }
 
-            while (chainActive.Tip()->nTime < 1471482000 || vNodes.empty() || pwallet->IsLocked() || !fMintableCoins || nReserveBalance >= pwallet->GetBalance() || !masternodeSync.IsSynced()) {
+            while (vNodes.empty() || pwallet->IsLocked() || !fMintableCoins || nReserveBalance >= pwallet->GetBalance() || !masternodeSync.IsSynced()) {
             	nLastCoinStakeSearchInterval = 0;
             	if (!fMintableCoins) {
             		if (GetTime() - nMintableLastCheck > 1 * 60) // 1 minute check time

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1237,25 +1237,33 @@ void BitcoinGUI::setStakingStatus()
         fMultiSend = pwalletMain->isMultiSendEnabled();
         stkStatus = pwalletMain->ReadStakingStatus();
     }
-
     if (!stkStatus || pwalletMain->stakingMode == StakingMode::STOPPED || pwalletMain->IsLocked()) {
         stakingState->setText(tr("Staking Disabled"));
         stakingState->setToolTip("Staking Disabled");
         stakingAction->setIcon(QIcon(":/icons/staking_inactive"));
         return;
     }
-
+    if (vNodes.empty()) {
+        stakingState->setText(tr("No Active Peers"));
+        stakingState->setToolTip("No Active Peers");
+        stakingAction->setIcon(QIcon(":/icons/staking_inactive"));
+        return;
+    }
+    if (IsInitialBlockDownload()) {
+        stakingState->setText(tr("Syncing..."));
+        stakingState->setToolTip("Syncing");
+        stakingAction->setIcon(QIcon(":/icons/staking_waiting"));
+        return;
+    }
     if (!masternodeSync.IsSynced()) {
         stakingState->setText(tr("Syncing MN List..."));
         stakingState->setToolTip("Syncing Masternode List");
         stakingAction->setIcon(QIcon(":/icons/staking_waiting"));
         return;
     }
-
     if (stakingState->text().contains("Enabling")) {
         if (!nLastCoinStakeSearchInterval) return;
     }
-
     if (nLastCoinStakeSearchInterval) {
         stakingState->setText(tr("Staking Enabled"));
         stakingState->setToolTip("Staking Enabled");

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1238,24 +1238,28 @@ void BitcoinGUI::setStakingStatus()
         stkStatus = pwalletMain->ReadStakingStatus();
     }
     if (!stkStatus || pwalletMain->stakingMode == StakingMode::STOPPED || pwalletMain->IsLocked()) {
+        LogPrint("staking","Checking Staking Status: Disabled.\n");
         stakingState->setText(tr("Staking Disabled"));
         stakingState->setToolTip("Staking Disabled");
         stakingAction->setIcon(QIcon(":/icons/staking_inactive"));
         return;
     }
     if (vNodes.empty()) {
+        LogPrint("staking","Checking Staking Status: No Active Peers...\n");
         stakingState->setText(tr("No Active Peers"));
         stakingState->setToolTip("No Active Peers");
         stakingAction->setIcon(QIcon(":/icons/staking_inactive"));
         return;
     }
     if (IsInitialBlockDownload()) {
+        LogPrint("staking","Checking Staking Status: Syncing...\n");
         stakingState->setText(tr("Syncing..."));
         stakingState->setToolTip("Syncing");
         stakingAction->setIcon(QIcon(":/icons/staking_waiting"));
         return;
     }
     if (!masternodeSync.IsSynced()) {
+        LogPrint("staking","Checking Staking Status: Syncing MN List...\n");
         stakingState->setText(tr("Syncing MN List..."));
         stakingState->setToolTip("Syncing Masternode List");
         stakingAction->setIcon(QIcon(":/icons/staking_waiting"));
@@ -1265,6 +1269,7 @@ void BitcoinGUI::setStakingStatus()
         if (!nLastCoinStakeSearchInterval) return;
     }
     if (nLastCoinStakeSearchInterval) {
+        LogPrint("staking","Checking Staking Status: Enabled.\n");
         stakingState->setText(tr("Staking Enabled"));
         stakingState->setToolTip("Staking Enabled");
         stakingAction->setIcon(QIcon(":/icons/staking_active"));
@@ -1274,6 +1279,7 @@ void BitcoinGUI::setStakingStatus()
         stakingState->setToolTip("Consolidating Transactions… Please wait few minutes for it to be consolidated.");
         stakingAction->setIcon(QIcon(":/icons/staking_active"));*/
     } else {
+        LogPrint("staking","Checking Staking Status: Enabling...\n");
         stakingState->setText(tr("Enabling Staking..."));
         stakingState->setToolTip("Enabling Staking... Please wait up to 1.5 hours for it to be properly enabled after consolidation.");
         stakingAction->setIcon(QIcon(":/icons/staking_active"));

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -499,7 +499,7 @@ void CoinControlDialog::updateDialogLabels()
     }
 
     vector<COutPoint> vCoinControl;
-    vector<COutput> vOutputs;
+    std::vector<COutput> vOutputs;
     coinControl->ListSelected(vCoinControl);
     model->getOutputs(vCoinControl, vOutputs);
 
@@ -560,7 +560,7 @@ void CoinControlDialog::updateLabels(WalletModel* model, QDialog* dialog)
     bool fAllowFree = false;
 
     vector<COutPoint> vCoinControl;
-    vector<COutput> vOutputs;
+    std::vector<COutput> vOutputs;
     coinControl->ListSelected(vCoinControl);
     model->getOutputs(vCoinControl, vOutputs);
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -133,7 +133,7 @@ OverviewPage::OverviewPage(QWidget* parent) : QDialog(parent, Qt::WindowSystemMe
 
     QTimer* timerBlockHeightLabel = new QTimer(this);
     connect(timerBlockHeightLabel, SIGNAL(timeout()), this, SLOT(showBlockCurrentHeight()));
-    timerBlockHeightLabel->start(45000);
+    timerBlockHeightLabel->start(60000);
 
     connect(ui->btnLockUnlock, SIGNAL(clicked()), this, SLOT(on_lockUnlock()));
 }

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -607,7 +607,7 @@ UniValue getmasternodeoutputs (const UniValue& params, bool fHelp)
             HelpExampleCli("getmasternodeoutputs", "") + HelpExampleRpc("getmasternodeoutputs", ""));
 
     // Find possible candidates
-    vector<COutput> possibleCoins = activeMasternode.SelectCoinsMasternode();
+    std::vector<COutput> possibleCoins = activeMasternode.SelectCoinsMasternode();
 
     UniValue ret(UniValue::VARR);
     for (COutput& out : possibleCoins) {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -382,7 +382,7 @@ UniValue listunspent(const UniValue& params, bool fHelp)
     }
 
     UniValue results(UniValue::VARR);
-    vector<COutput> vecOutputs;
+    std::vector<COutput> vecOutputs;
     assert(pwalletMain != NULL);
     LOCK2(cs_main, pwalletMain->cs_wallet);
     pwalletMain->AvailableCoins(vecOutputs, false);

--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -67,7 +67,7 @@ static void generate_block(int count) {
 
 #ifdef DISABLE_FAILED_TEST
 static CWallet wallet;
-static vector<COutput> vCoins;
+static std::vector<COutput> vCoins;
 
 static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = false, int nInput=0)
 {

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -67,7 +67,7 @@ static void generate_block(int count) {
 
 #ifdef DISABLE_FAILED_TEST
 static CWallet wallet;
-static vector<COutput> vCoins;
+static std::vector<COutput> vCoins;
 
 static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = false, int nInput=0)
 {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2050,7 +2050,7 @@ bool CWallet::AvailableCoins(const uint256 wtxid, const CWalletTx* pcoin, vector
 
 map<CBitcoinAddress, vector<COutput> > CWallet::AvailableCoinsByAddress(bool fConfirmed, CAmount maxCoinValue)
 {
-    vector<COutput> vCoins;
+    std::vector<COutput> vCoins;
     AvailableCoins(vCoins, fConfirmed);
 
     map<CBitcoinAddress, vector<COutput> > mapCoins;
@@ -2136,7 +2136,7 @@ bool less_then_denom(const COutput& out1, const COutput& out2)
 
 bool CWallet::SelectStakeCoins(std::set<std::pair<const CWalletTx*, unsigned int> >& setCoins, CAmount nTargetAmount)
 {
-    vector<COutput> vCoins;
+    std::vector<COutput> vCoins;
     AvailableCoins(vCoins, true, NULL, false, STAKABLE_COINS);
     CAmount nAmountSelected = 0;
 
@@ -2165,7 +2165,7 @@ bool CWallet::SelectStakeCoins(std::set<std::pair<const CWalletTx*, unsigned int
 
 bool CWallet::MintableCoins()
 {
-    vector<COutput> vCoins;
+    std::vector<COutput> vCoins;
 
     {
         LOCK2(cs_main, cs_wallet);
@@ -2207,7 +2207,7 @@ StakingStatusError CWallet::StakingCoinStatus(CAmount& minFee, CAmount& maxFee)
         return StakingStatusError::UNSTAKABLE_BALANCE_RESERVE_TOO_HIGH;
     }
 
-    vector<COutput> vCoins, coinsUnderThreshold, coinsOverThreshold;
+    std::vector<COutput> vCoins, coinsUnderThreshold, coinsOverThreshold;
     StakingStatusError ret = StakingStatusError::STAKING_OK;
     CAmount nSpendableBalance = GetSpendableBalance();
 
@@ -2341,7 +2341,7 @@ StakingStatusError CWallet::StakingCoinStatus(CAmount& minFee, CAmount& maxFee)
     return ret;
 }
 
-bool CWallet::SelectCoinsMinConf(bool needFee, CAmount& feeNeeded, int ringSize, int numOut, const CAmount& nTargetValue, int nConfMine, int nConfTheirs, vector<COutput> vCoins, set<pair<const CWalletTx*, unsigned int> >& setCoinsRet, CAmount& nValueRet)
+bool CWallet::SelectCoinsMinConf(bool needFee, CAmount& feeNeeded, int ringSize, int numOut, const CAmount& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, set<pair<const CWalletTx*, unsigned int> >& setCoinsRet, CAmount& nValueRet)
 {
     setCoinsRet.clear();
     nValueRet = 0;
@@ -2521,7 +2521,7 @@ void CWallet::resetPendingOutPoints()
 bool CWallet::SelectCoins(bool needFee, CAmount& estimatedFee, int ringSize, int numOut, const CAmount& nTargetValue, set<pair<const CWalletTx*, unsigned int> >& setCoinsRet, CAmount& nValueRet, const CCoinControl* coinControl, AvailableCoinsType coin_type, bool useIX)
 {
     // Note: this function should never be used for "always free" tx types like dstx
-    vector<COutput> vCoins;
+    std::vector<COutput> vCoins;
     vCoins.clear();
 
     {
@@ -2613,7 +2613,7 @@ bool CWallet::SelectCoinsByDenominations(int nDenom, CAmount nValueMin, CAmount 
     nValueRet = 0;
 
     vCoinsRet2.clear();
-    vector<COutput> vCoins;
+    std::vector<COutput> vCoins;
     AvailableCoins(vCoins, true, NULL, false, ONLY_DENOMINATED);
 
     std::random_shuffle(vCoins.rbegin(), vCoins.rend());
@@ -2733,7 +2733,7 @@ bool CWallet::SelectCoinsDark(CAmount nValueMin, CAmount nValueMax, std::vector<
     setCoinsRet.clear();
     nValueRet = 0;
 
-    vector<COutput> vCoins;
+    std::vector<COutput> vCoins;
     AvailableCoins(vCoins, true, coinControl, false, nObfuscationRoundsMin < 0 ? ONLY_NONDENOMINATED_NOT1000000IFMN : ONLY_DENOMINATED);
 
     set<pair<const CWalletTx*, unsigned int> > setCoinsRet2;
@@ -2772,7 +2772,7 @@ bool CWallet::SelectCoinsDark(CAmount nValueMin, CAmount nValueMax, std::vector<
 
 bool CWallet::SelectCoinsCollateral(std::vector<CTxIn>& setCoinsRet, CAmount& nValueRet)
 {
-    vector<COutput> vCoins;
+    std::vector<COutput> vCoins;
 
     AvailableCoins(vCoins);
 
@@ -2824,7 +2824,7 @@ int CWallet::CountInputsWithAmount(CAmount nInputAmount)
 
 bool CWallet::HasCollateralInputs(bool fOnlyConfirmed)
 {
-    vector<COutput> vCoins;
+    std::vector<COutput> vCoins;
     AvailableCoins(vCoins, fOnlyConfirmed);
 
     int nFound = 0;
@@ -4196,7 +4196,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
             // Make sure the wallet is unlocked and shutdown hasn't been requested
             if (IsLocked() || ShutdownRequested())
                     return false;
-            vector<COutput> vCoins;
+            std::vector<COutput> vCoins;
             int cannotSpend = 0;
             {
                 AvailableCoins(wtxid, pcoin, vCoins, cannotSpend, true, NULL, false, STAKABLE_COINS, false);
@@ -5584,7 +5584,7 @@ bool CWallet::SendAll(std::string des)
     }
 
     CAmount total = 0;
-    vector<COutput> vCoins;
+    std::vector<COutput> vCoins;
     vCoins.clear();
     std::string strFailReason;
     bool ret = true;
@@ -5779,7 +5779,7 @@ bool CWallet::CreateSweepingTransaction(CAmount target, CAmount threshold, uint3
         return false;
     }
     CAmount total = 0;
-    vector<COutput> vCoins;
+    std::vector<COutput> vCoins;
     COutput lowestLarger(NULL, 0, 0, false);
     CAmount currentLowestLargerAmount = 0;
     vCoins.clear();
@@ -6057,7 +6057,7 @@ void CWallet::AutoCombineDust()
 bool CWallet::estimateStakingConsolidationFees(CAmount& minFee, CAmount& maxFee) {
     //finding all spendable UTXOs < MIN_STAKING
     CAmount total = 0;
-	vector<COutput> vCoins, underStakingThresholdCoins;
+    std::vector<COutput> vCoins, underStakingThresholdCoins;
 	{
 		LOCK2(cs_main, cs_wallet);
 		{


### PR DESCRIPTION
- Add "No Active Peers"/"Syncing..." status' to setStakingStatus (visual staking status)
->Different from !masternodeSync.IsSynced() - Syncing will check for IsInitialBlockDownload
- Move reserveBalance within #ifdef ENABLE_WALLET (requires wallet)
- Remove excessive logs re: staking/nTime violations
- Remove unnecessary check in Miner
- Restore sleep timer in miner with setting in conf file 'minersleep', 30sec default
- Change timerBlockHeightLabel from 45s->60s (60s block times anyway)