### PR TITLE
Add Basic Litemode

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -623,8 +623,10 @@ void BitcoinGUI::createToolBars()
         bottomToolbar->setOrientation(Qt::Vertical);
         bottomToolbar->addAction(optionsAction);
         bottomToolbar->addSeparator();
-        bottomToolbar->addAction(stakingAction);
-        bottomToolbar->addWidget(stakingState);
+        if (!fLiteMode) {
+            bottomToolbar->addAction(stakingAction);
+            bottomToolbar->addWidget(stakingState);
+        }
         bottomToolbar->addAction(networkAction);
         bottomToolbar->addWidget(connectionCount);
         bottomToolbar->setStyleSheet("QToolBar{spacing:5px;}");

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -119,6 +119,7 @@ BitcoinGUI::BitcoinGUI(const NetworkStyle* networkStyle, QWidget* parent) : QMai
     GUIUtil::restoreWindowGeometry("nWindow", QSize(1147, 768), this);
 
     QString windowTitle = tr("DAPS Coin") + " ";
+    fLiteMode = GetBoolArg("-litemode", false);
 #ifdef ENABLE_WALLET
     /* if compiled with wallet support, -disablewallet can still disable the wallet */
     enableWallet = !GetBoolArg("-disablewallet", false);
@@ -129,6 +130,9 @@ BitcoinGUI::BitcoinGUI(const NetworkStyle* networkStyle, QWidget* parent) : QMai
         windowTitle += tr("Keychain Wallet");
     } else {
         windowTitle += tr("Node");
+    }
+    if (fLiteMode) {
+        windowTitle += tr(" - Lite Mode");
     }
     QString userWindowTitle = QString::fromStdString(GetArg("-windowtitle", ""));
     if (!userWindowTitle.isEmpty()) windowTitle += " - " + userWindowTitle;
@@ -329,7 +333,9 @@ void BitcoinGUI::createActions(const NetworkStyle* networkStyle)
 #else
         masternodeAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_5));
 #endif
-        tabGroup->addAction(masternodeAction);
+        if (!fLiteMode) {
+            tabGroup->addAction(masternodeAction);
+        }
         connect(masternodeAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
         connect(masternodeAction, SIGNAL(triggered()), this, SLOT(gotoMasternodePage()));
 
@@ -603,8 +609,9 @@ void BitcoinGUI::createToolBars()
         toolbar->addAction(sendCoinsAction);
         toolbar->addAction(receiveCoinsAction);
         toolbar->addAction(historyAction);
-        toolbar->addAction(masternodeAction);
-
+        if (!fLiteMode) {
+            toolbar->addAction(masternodeAction);
+        }
         toolbar->setMovable(false); // remove unused icon in upper left corner
         overviewAction->setChecked(true);
         toolbar->setStyleSheet("QToolBar{spacing:25px;}");
@@ -788,7 +795,9 @@ void BitcoinGUI::createTrayIconMenu()
     trayIconMenu->addAction(sendCoinsAction);
     trayIconMenu->addAction(receiveCoinsAction);
     trayIconMenu->addAction(historyAction);
-    trayIconMenu->addAction(masternodeAction);
+    if (!fLiteMode) {
+        trayIconMenu->addAction(masternodeAction);
+    }
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(optionsAction);
     trayIconMenu->addSeparator();

--- a/src/qt/forms/optionspage.ui
+++ b/src/qt/forms/optionspage.ui
@@ -311,7 +311,7 @@
           <enum>QLayout::SetDefaultConstraint</enum>
          </property>
          <item>
-          <widget class="QLabel" name="label_2">
+          <widget class="QLabel" name="quantityLabel">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
              <horstretch>0</horstretch>
@@ -608,7 +608,7 @@
          </item>
         </layout>
        </item>
-	          <item>
+       <item>
         <widget class="QLabel" name="line_4">
          <property name="enabled">
           <bool>true</bool>

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -35,6 +35,10 @@ SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle* networkStyle) 
 
     // define text to place
     QString titleText = tr("DAPS Coin Keychain Wallet");
+    fLiteMode = GetBoolArg("-litemode", false);
+    if (fLiteMode) {
+        titleText = tr("DAPS Coin Lite Mode Wallet");
+    }
     QString versionText = QString(tr("Version %1")).arg(QString::fromStdString(FormatFullVersion()));
     QString copyrightTextBtc = QChar(0xA9) + QString(" 2009-%1 ").arg(COPYRIGHT_YEAR) + QString(tr("The Bitcoin Core developers"));
     QString copyrightTextDash = QChar(0xA9) + QString(" 2014-%1 ").arg(COPYRIGHT_YEAR) + QString(tr("The Dash Core developers"));


### PR DESCRIPTION
Add a basic Lite Mode (litemode=1) 
This hides the masternode tab and disables staking (button and function) for a "Lite" wallet.

This will be expanded on in the future.

![image](https://user-images.githubusercontent.com/2319897/72385442-81242480-36ed-11ea-892c-7da2348d9136.png)

![image](https://user-images.githubusercontent.com/2319897/72385439-7e293400-36ed-11ea-9f22-d976d81b870e.png)
