### PR TITLE
Fixes for Lite Mode

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -636,8 +636,8 @@ void BitcoinGUI::createToolBars()
             stakingState->setVisible(false);
         }
 
-        QHBoxLayout* layout = new QHBoxLayout(this);
-        QVBoxLayout* navLayout = new QVBoxLayout(this);
+        QHBoxLayout* layout = new QHBoxLayout();
+        QVBoxLayout* navLayout = new QVBoxLayout();
         QWidget* navWidget = new QWidget(this);
         navWidget->setObjectName("navLayout");
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -250,10 +250,12 @@ BitcoinGUI::BitcoinGUI(const NetworkStyle* networkStyle, QWidget* parent) : QMai
     // Subscribe to notifications from core
     subscribeToCoreSignals();
 
-    QTimer* timerStakingIcon = new QTimer(labelStakingIcon);
-    connect(timerStakingIcon, SIGNAL(timeout()), this, SLOT(setStakingStatus()));
-    timerStakingIcon->start(10000);
-    setStakingStatus();
+    if (!fLiteMode) {
+        QTimer* timerStakingIcon = new QTimer(labelStakingIcon);
+        connect(timerStakingIcon, SIGNAL(timeout()), this, SLOT(setStakingStatus()));
+        timerStakingIcon->start(10000);
+        setStakingStatus();
+    }
 }
 
 BitcoinGUI::~BitcoinGUI()
@@ -623,15 +625,16 @@ void BitcoinGUI::createToolBars()
         bottomToolbar->setOrientation(Qt::Vertical);
         bottomToolbar->addAction(optionsAction);
         bottomToolbar->addSeparator();
-        if (!fLiteMode) {
-            bottomToolbar->addAction(stakingAction);
-            bottomToolbar->addWidget(stakingState);
-        }
+        bottomToolbar->addAction(stakingAction);
+        bottomToolbar->addWidget(stakingState);
         bottomToolbar->addAction(networkAction);
         bottomToolbar->addWidget(connectionCount);
         bottomToolbar->setStyleSheet("QToolBar{spacing:5px;}");
-
         bottomToolbar->setObjectName("bottomToolbar");
+        if (fLiteMode) {
+            stakingAction->setVisible(false);
+            stakingState->setVisible(false);
+        }
 
         QHBoxLayout* layout = new QHBoxLayout(this);
         QVBoxLayout* navLayout = new QVBoxLayout(this);

--- a/src/qt/dapscoin.cpp
+++ b/src/qt/dapscoin.cpp
@@ -526,6 +526,9 @@ void BitcoinApplication::initializeResult(int retval)
                 unlockdlg.setStyleSheet(GUIUtil::loadStyleSheet());
                 if (unlockdlg.exec() == QDialog::Accepted) {
                     walletUnlocked = true;
+                    if (fLiteMode) {
+                        pwalletMain->WriteStakingStatus(false);
+                    }
                 }
                 emit requestedRegisterNodeSignal();
             }

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -246,7 +246,6 @@ void OverviewPage::setWalletModel(WalletModel* model)
     this->walletModel = model;
     if (model && model->getOptionsModel()) {
         // Set up transaction list
-        LogPrintf("%s:setWalletModel\n", __func__);
         filter = new TransactionFilterProxy(this);
         filter->setSourceModel(model->getTransactionTableModel());
         filter->setLimit(NUM_ITEMS);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -187,7 +187,7 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
         ui->labelUnconfirmed->setText("Locked; Hidden");
         ui->btnLockUnlock->setStyleSheet("border-image: url(:/images/lock) 0 0 0 0 stretch stretch; width: 20px;");
     } else {
-        if (stkStatus && !nLastCoinStakeSearchInterval) {
+        if (stkStatus && !nLastCoinStakeSearchInterval && !fLiteMode) {
             ui->labelBalance_2->setText("Enabling Staking...");
             ui->labelBalance_2->setToolTip("Enabling Staking... Please wait up to 1.5 hours for it to be properly enabled after consolidation.");
             ui->labelBalance->setText("Enabling Staking...");

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -45,7 +45,7 @@ WalletView::WalletView(QWidget* parent) : QStackedWidget(parent),
     overviewPage = new OverviewPage();
     explorerWindow = new BlockExplorer(this);
     transactionsPage = new QWidget(this);
-    QVBoxLayout* vbox = new QVBoxLayout(this);
+    QVBoxLayout* vbox = new QVBoxLayout();
     QHBoxLayout* hbox_buttons = new QHBoxLayout();
     transactionView = new TransactionView(this);
     vbox->addWidget(transactionView);


### PR DESCRIPTION
- Fix "Staking" word randomly stuck in the file menu
- Fix "Enabling Staking" still displaying on Overview
- Disable staking icon timer
- Force WriteStakingStatus(false) after unlock to disable staking

- Remove extra log in overviewpage.cpp