### PR TITLE
[Upstream][Wallet] Add function CMerkleTx::IsInMainChainImmature

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -905,16 +905,9 @@ public:
      * >=1 : this many blocks deep in the main chain
      */
     int GetDepthInMainChain(const CBlockIndex*& pindexRet, bool enableIX = true) const;
-    int GetDepthInMainChain(bool enableIX = true) const
-    {
-        const CBlockIndex* pindexRet;
-        return GetDepthInMainChain(pindexRet, enableIX);
-    }
-    bool IsInMainChain() const
-    {
-        const CBlockIndex* pindexRet;
-        return GetDepthInMainChainINTERNAL(pindexRet) > 0;
-    }
+    int GetDepthInMainChain(bool enableIX = true) const;
+    bool IsInMainChain() const;
+    bool IsInMainChainImmature() const;
     int GetBlocksToMaturity() const;
     bool AcceptToMemoryPool(bool fLimitFree = true, bool fRejectInsaneFee = true, bool ignoreFees = false);
     int GetTransactionLockSignatures() const;


### PR DESCRIPTION
> This introduces a little performance optimization, removing the double call to `GetDepthInMainChain` (ref: [#1281 (comment)](https://github.com/PIVX-Project/PIVX/pull/1281#discussion_r369861492)).
> 
> Note: in a successive PR we should review the LOCKs in this area of the wallet.

from https://github.com/PIVX-Project/PIVX/pull/1300