### PR TITLE
[Upstream] Sync upgrade, part 3

### DIFF
--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -26,7 +26,7 @@ class CActiveMasternode
 {
 private:
     // critical section to protect the inner data structures
-    mutable CCriticalSection cs;
+    mutable RecursiveMutex cs;
 
     /// Ping Masternode
     bool SendMasternodePing(std::string& errorMessage);

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -170,7 +170,7 @@ class CAddrMan
 {
 private:
     //! critical section to protect the inner data structures
-    mutable CCriticalSection cs;
+    mutable RecursiveMutex cs;
 
     //! secret key to randomize bucket select with
     uint256 nKey;

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -24,7 +24,7 @@
 using namespace std;
 
 map<uint256, CAlert> mapAlerts;
-CCriticalSection cs_mapAlerts;
+RecursiveMutex cs_mapAlerts;
 
 void CUnsignedAlert::SetNull()
 {

--- a/src/alert.h
+++ b/src/alert.h
@@ -19,7 +19,7 @@ class CNode;
 class uint256;
 
 extern std::map<uint256, CAlert> mapAlerts;
-extern CCriticalSection cs_mapAlerts;
+extern RecursiveMutex cs_mapAlerts;
 
 /** Alerts are for notifying old versions if they become too obsolete and
  * need to upgrade.  The message is displayed in the status bar.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -180,7 +180,7 @@ void PrepareShutdown()
     fRequestShutdown = true;  // Needed when we shutdown the wallet
     fRestartRequested = true; // Needed when we restart the wallet
     LogPrintf("%s: In progress...\n", __func__);
-    static CCriticalSection cs_Shutdown;
+    static RecursiveMutex cs_Shutdown;
     TRY_LOCK(cs_Shutdown, lockShutdown);
     if (!lockShutdown)
         return;

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -21,7 +21,7 @@ class CScriptID;
 class CKeyStore
 {
 protected:
-    mutable CCriticalSection cs_KeyStore;
+    mutable RecursiveMutex cs_KeyStore;
 
 public:
     virtual ~CKeyStore() {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,7 +53,18 @@ using namespace std;
  * Global state
  */
 
-CCriticalSection cs_main;
+
+/**
+ * Mutex to guard access to validation specific variables, such as reading
+ * or changing the chainstate.
+ *
+ * This may also need to be locked when updating the transaction pool, e.g. on
+ * AcceptToMemoryPool. See CTxMemPool::cs comment for details.
+ *
+ * The transaction pool has a separate lock to allow reading from it and the
+ * chainstate at the same time.
+ */
+RecursiveMutex cs_main;
 
 BlockMap mapBlockIndex;
 map<uint256, uint256> mapProofOfStake;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3211,7 +3211,7 @@ void static UpdateTip(CBlockIndex* pindexNew)
     mempool.AddTransactionsUpdated(1);
 
     {
-        WaitableLock lock(g_best_block_mutex);
+        LOCK(g_best_block_mutex);
         g_best_block = pindexNew->GetBlockHash();
         g_best_block_cv.notify_all();
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -160,7 +160,7 @@ int nSyncStarted = 0;
 /** All pairs A->B, where A (or one if its ancestors) misses transactions, but B has transactions. */
 multimap<CBlockIndex*, CBlockIndex*> mapBlocksUnlinked;
 
-CCriticalSection cs_LastBlockFile;
+RecursiveMutex cs_LastBlockFile;
 std::vector<CBlockFileInfo> vinfoBlockFile;
 int nLastBlockFile = 0;
 
@@ -168,7 +168,7 @@ int nLastBlockFile = 0;
      * Every received block is assigned a unique and increasing identifier, so we
      * know which one to give priority in case of a fork.
      */
-CCriticalSection cs_nBlockSequenceId;
+RecursiveMutex cs_nBlockSequenceId;
 /** Blocks loaded from disk are assigned id 0, so start the counter at 1. */
 uint32_t nBlockSequenceId = 1;
 
@@ -1760,7 +1760,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
             // This mitigates 'penny-flooding' -- sending thousands of free transactions just to
             // be annoying or make others' transactions take longer to confirm.
             if (fLimitFree && nFees < ::minRelayTxFee.GetFee(nSize - 300)) {
-                static CCriticalSection csFreeLimiter;
+                static RecursiveMutex csFreeLimiter;
                 static double dFreeCount;
                 static int64_t nLastTime;
                 int64_t nNow = GetTime();
@@ -1964,7 +1964,7 @@ bool AcceptableInputs(CTxMemPool& pool, CValidationState& state, const CTransact
             // This mitigates 'penny-flooding' -- sending thousands of free transactions just to
             // be annoying or make others' transactions take longer to confirm.
             if (fLimitFree && nFees < ::minRelayTxFee.GetFee(nSize)) {
-                static CCriticalSection csFreeLimiter;
+                static RecursiveMutex csFreeLimiter;
                 static double dFreeCount;
                 static int64_t nLastTime;
                 int64_t nNow = GetTime();

--- a/src/main.h
+++ b/src/main.h
@@ -132,7 +132,7 @@ struct BlockHasher {
 };
 
 extern CScript COINBASE_FLAGS;
-extern CCriticalSection cs_main;
+extern RecursiveMutex cs_main;
 extern CTxMemPool mempool;
 typedef boost::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
 extern BlockMap mapBlockIndex;

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -17,7 +17,7 @@
 #include <boost/filesystem.hpp>
 
 CBudgetManager budget;
-CCriticalSection cs_budget;
+RecursiveMutex cs_budget;
 
 std::map<uint256, int64_t> askedForSourceProposalOrBudget;
 std::vector<CBudgetProposalBroadcast> vecImmatureBudgetProposals;

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -18,7 +18,7 @@
 
 using namespace std;
 
-extern CCriticalSection cs_budget;
+extern RecursiveMutex cs_budget;
 
 class CBudgetManager;
 class CFinalizedBudgetBroadcast;
@@ -179,7 +179,7 @@ private:
 
 public:
     // critical section to protect the inner data structures
-    mutable CCriticalSection cs;
+    mutable RecursiveMutex cs;
 
     // keep track of the scanning errors I've seen
     map<uint256, CBudgetProposal> mapProposals;
@@ -308,7 +308,7 @@ class CFinalizedBudget
 {
 private:
     // critical section to protect the inner data structures
-    mutable CCriticalSection cs;
+    mutable RecursiveMutex cs;
     bool fAutoChecked; //If it matches what we see, we'll auto vote for it (masternode only)
 
 public:
@@ -453,7 +453,7 @@ class CBudgetProposal
 {
 private:
     // critical section to protect the inner data structures
-    mutable CCriticalSection cs;
+    mutable RecursiveMutex cs;
     CAmount nAlloted;
 
 public:

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -18,9 +18,9 @@
 /** Object for who's going to get paid on which blocks */
 CMasternodePayments masternodePayments;
 
-CCriticalSection cs_vecPayments;
-CCriticalSection cs_mapMasternodeBlocks;
-CCriticalSection cs_mapMasternodePayeeVotes;
+RecursiveMutex cs_vecPayments;
+RecursiveMutex cs_mapMasternodeBlocks;
+RecursiveMutex cs_mapMasternodePayeeVotes;
 
 //
 // CMasternodePaymentDB

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -13,9 +13,9 @@
 
 using namespace std;
 
-extern CCriticalSection cs_vecPayments;
-extern CCriticalSection cs_mapMasternodeBlocks;
-extern CCriticalSection cs_mapMasternodePayeeVotes;
+extern RecursiveMutex cs_vecPayments;
+extern RecursiveMutex cs_mapMasternodeBlocks;
+extern RecursiveMutex cs_mapMasternodePayeeVotes;
 
 class CMasternodePayments;
 class CMasternodePaymentWinner;

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -109,7 +109,7 @@ class CMasternode
 {
 private:
     // critical section to protect the inner data structures
-    mutable CCriticalSection cs;
+    mutable RecursiveMutex cs;
     int64_t lastTimeChecked;
 
 public:

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -53,10 +53,10 @@ class CMasternodeMan
 {
 private:
     // critical section to protect the inner data structures
-    mutable CCriticalSection cs;
+    mutable RecursiveMutex cs;
 
     // critical section to protect the inner data structures specifically on messaging
-    mutable CCriticalSection cs_process_message;
+    mutable RecursiveMutex cs_process_message;
 
     // map to hold all MNs
     std::vector<CMasternode> vMasternodes;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -791,7 +791,7 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake, MineType mineType)
             } else
                 nHashCounter += nHashesDone;
             if (GetTimeMillis() - nHPSTimerStart > 4000) {
-                static CCriticalSection cs;
+                static RecursiveMutex cs;
                 {
                     LOCK(cs);
                     if (GetTimeMillis() - nHPSTimerStart > 4000) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -612,7 +612,7 @@ bool ProcessBlockFound(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey)
 
     // Found a solution
     {
-        WaitableLock lock(g_best_block_mutex);
+        WAIT_LOCK(g_best_block_mutex, lock);
         if (pblock->hashPrevBlock != g_best_block)
             return error("DAPScoinMiner : generated block is stale");
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -77,7 +77,7 @@ namespace {
 bool fDiscover = true;
 bool fListen = true;
 uint64_t nLocalServices = NODE_NETWORK;
-CCriticalSection cs_mapLocalHost;
+RecursiveMutex cs_mapLocalHost;
 map <CNetAddr, LocalServiceInfo> mapLocalHost;
 //static bool vfReachable[NET_MAX] = {};
 static bool vfLimited[NET_MAX] = {};
@@ -90,23 +90,23 @@ bool fAddressesInitialized = false;
 std::string strSubVersion;
 
 vector<CNode *> vNodes;
-CCriticalSection cs_vNodes;
+RecursiveMutex cs_vNodes;
 map <CInv, CDataStream> mapRelay;
 deque <pair<int64_t, CInv>> vRelayExpiration;
-CCriticalSection cs_mapRelay;
+RecursiveMutex cs_mapRelay;
 limitedmap<CInv, int64_t> mapAlreadyAskedFor(MAX_INV_SZ);
 
 static deque <string> vOneShots;
-CCriticalSection cs_vOneShots;
+RecursiveMutex cs_vOneShots;
 
 set <CNetAddr> setservAddNodeAddresses;
-CCriticalSection cs_setservAddNodeAddresses;
+RecursiveMutex cs_setservAddNodeAddresses;
 
 vector <std::string> vAddedNodes;
-CCriticalSection cs_vAddedNodes;
+RecursiveMutex cs_vAddedNodes;
 
 NodeId nLastNodeId = 0;
-CCriticalSection cs_nLastNodeId;
+RecursiveMutex cs_nLastNodeId;
 
 static CSemaphore *semOutbound = NULL;
 boost::condition_variable messageHandlerCondition;
@@ -325,8 +325,8 @@ void AddressCurrentlyConnected(const CService &addr) {
 
 uint64_t CNode::nTotalBytesRecv = 0;
 uint64_t CNode::nTotalBytesSent = 0;
-CCriticalSection CNode::cs_totalBytesRecv;
-CCriticalSection CNode::cs_totalBytesSent;
+RecursiveMutex CNode::cs_totalBytesRecv;
+RecursiveMutex CNode::cs_totalBytesSent;
 
 CNode *FindNode(const CNetAddr &ip) {
     LOCK(cs_vNodes);
@@ -471,7 +471,7 @@ void CNode::PushVersion() {
 
 
 banmap_t CNode::setBanned;
-CCriticalSection CNode::cs_setBanned;
+RecursiveMutex CNode::cs_setBanned;
 bool CNode::setBannedIsDirty;
 
 void CNode::ClearBanned() {
@@ -613,7 +613,7 @@ void CNode::SetBannedSetDirty(bool dirty) {
 }
 
 std::vector <CSubNet> CNode::vWhitelistedRange;
-CCriticalSection CNode::cs_vWhitelistedRange;
+RecursiveMutex CNode::cs_vWhitelistedRange;
 
 bool CNode::IsWhitelistedRange(const CNetAddr &addr) {
     LOCK(cs_vWhitelistedRange);

--- a/src/net.h
+++ b/src/net.h
@@ -132,17 +132,17 @@ extern CAddrMan addrman;
 extern int nMaxConnections;
 
 extern std::vector<CNode*> vNodes;
-extern CCriticalSection cs_vNodes;
+extern RecursiveMutex cs_vNodes;
 extern std::map<CInv, CDataStream> mapRelay;
 extern std::deque<std::pair<int64_t, CInv> > vRelayExpiration;
-extern CCriticalSection cs_mapRelay;
+extern RecursiveMutex cs_mapRelay;
 extern limitedmap<CInv, int64_t> mapAlreadyAskedFor;
 
 extern std::vector<std::string> vAddedNodes;
-extern CCriticalSection cs_vAddedNodes;
+extern RecursiveMutex cs_vAddedNodes;
 
 extern NodeId nLastNodeId;
-extern CCriticalSection cs_nLastNodeId;
+extern RecursiveMutex cs_nLastNodeId;
 
 /** Subversion as sent to the P2P network in `version` messages */
 extern std::string strSubVersion;
@@ -152,7 +152,7 @@ struct LocalServiceInfo {
     int nPort;
 };
 
-extern CCriticalSection cs_mapLocalHost;
+extern RecursiveMutex cs_mapLocalHost;
 extern std::map<CNetAddr, LocalServiceInfo> mapLocalHost;
 
 class CNodeStats
@@ -291,11 +291,11 @@ public:
     size_t nSendOffset; // offset inside the first vSendMsg already sent
     uint64_t nSendBytes;
     std::deque<CSerializeData> vSendMsg;
-    CCriticalSection cs_vSend;
+    RecursiveMutex cs_vSend;
 
     std::deque<CInv> vRecvGetData;
     std::deque<CNetMessage> vRecvMsg;
-    CCriticalSection cs_vRecvMsg;
+    RecursiveMutex cs_vRecvMsg;
     uint64_t nRecvBytes;
     int nRecvVersion;
 
@@ -331,7 +331,7 @@ public:
     // For such cases node should be released manually (preferably right after corresponding code).
     bool fObfuScationMaster;
     CSemaphoreGrant grantOutbound;
-    CCriticalSection cs_filter;
+    RecursiveMutex cs_filter;
     CBloomFilter* pfilter;
     int nRefCount;
     NodeId id;
@@ -340,7 +340,7 @@ protected:
     // Denial-of-service detection/prevention
     // Key is IP address, value is banned-until-time
     static banmap_t setBanned;
-    static CCriticalSection cs_setBanned;
+    static RecursiveMutex cs_setBanned;
     static bool setBannedIsDirty;
 
     std::vector<std::string> vecRequestsFulfilled; //keep track of what client has asked for
@@ -348,7 +348,7 @@ protected:
     // Whitelisted ranges. Any node connecting from these is automatically
     // whitelisted (as well as those connecting to whitelisted binds).
     static std::vector<CSubNet> vWhitelistedRange;
-    static CCriticalSection cs_vWhitelistedRange;
+    static RecursiveMutex cs_vWhitelistedRange;
 
     // Basic fuzz-testing
     void Fuzz(int nChance); // modifies ssSend
@@ -366,7 +366,7 @@ public:
     // inventory based relay
     mruset<CInv> setInventoryKnown;
     std::vector<CInv> vInventoryToSend;
-    CCriticalSection cs_inventory;
+    RecursiveMutex cs_inventory;
     std::multimap<int64_t, CInv> mapAskFor;
     std::vector<uint256> vBlockRequested;
 
@@ -385,8 +385,8 @@ public:
 
 private:
     // Network usage totals
-    static CCriticalSection cs_totalBytesRecv;
-    static CCriticalSection cs_totalBytesSent;
+    static RecursiveMutex cs_totalBytesRecv;
+    static RecursiveMutex cs_totalBytesSent;
     static uint64_t nTotalBytesRecv;
     static uint64_t nTotalBytesSent;
 

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -40,7 +40,7 @@ using namespace std;
 // Settings
 static proxyType proxyInfo[NET_MAX];
 static proxyType nameProxy;
-static CCriticalSection cs_proxyInfos;
+static RecursiveMutex cs_proxyInfos;
 int nConnectTimeout = DEFAULT_CONNECT_TIMEOUT;
 bool fNameLookup = false;
 

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -17,7 +17,7 @@
 #include <QErrorMessage>
 #include <QTimer>
 
-CCriticalSection cs_masternodes;
+RecursiveMutex cs_masternodes;
 
 MasternodeList::MasternodeList(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint | Qt::WindowCloseButtonHint),
                                                   ui(new Ui::MasternodeList),

--- a/src/qt/masternodelist.h
+++ b/src/qt/masternodelist.h
@@ -63,7 +63,7 @@ private:
     Ui::MasternodeList* ui;
     ClientModel* clientModel;
     WalletModel* walletModel;
-    CCriticalSection cs_mnlistupdate;
+    RecursiveMutex cs_mnlistupdate;
     QString strCurrentFilter;
     virtual void resizeEvent(QResizeEvent* event);
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -528,7 +528,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         {
             checktxtime = std::chrono::steady_clock::now() + std::chrono::minutes(1);
 
-            WaitableLock lock(g_best_block_mutex);
+            WAIT_LOCK(g_best_block_mutex, lock);
             while (g_best_block == hashWatchedChain && IsRPCRunning()) {
                 if (g_best_block_cv.wait_until(lock, checktxtime) == std::cv_status::timeout)
                 {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -38,7 +38,7 @@ using namespace std;
 static bool fRPCRunning = false;
 static bool fRPCInWarmup = true;
 static std::string rpcWarmupStatus("RPC server started");
-static CCriticalSection cs_rpcWarmup;
+static RecursiveMutex cs_rpcWarmup;
 
 /* Timer-creating functions */
 static RPCTimerInterface* timerInterface = NULL;

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -71,7 +71,7 @@ typedef std::set<std::pair<void*, void*> > InvLockOrders;
 struct LockData {
     // Very ugly hack: as the global constructs and destructors run single
     // threaded, we use this boolean to know whether LockData still exists,
-    // as DeleteLock can get called by global CCriticalSection destructors
+    // as DeleteLock can get called by global RecursiveMutex destructors
     // after LockData disappears.
     bool available;
     LockData() : available(true) {}

--- a/src/sync.h
+++ b/src/sync.h
@@ -97,6 +97,7 @@ public:
     {
         return PARENT::try_lock();
     }
+
     using UniqueLock = std::unique_lock<PARENT>;
 };
 
@@ -105,7 +106,6 @@ public:
  * TODO: We should move away from using the recursive lock by default.
  */
 using RecursiveMutex = AnnotatedMixin<std::recursive_mutex>;
-typedef AnnotatedMixin<std::recursive_mutex> CCriticalSection;
 
 /** Wrapped mutex: supports waiting but not recursive locking */
 typedef AnnotatedMixin<std::mutex> Mutex;

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -23,7 +23,7 @@ BOOST_AUTO_TEST_SUITE(util_tests)
 
 BOOST_AUTO_TEST_CASE(util_criticalsection)
 {
-    CCriticalSection cs;
+    RecursiveMutex cs;
 
     do {
         LOCK(cs);

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -12,7 +12,7 @@
 
 using namespace std;
 
-static CCriticalSection cs_nTimeOffset;
+static RecursiveMutex cs_nTimeOffset;
 static int64_t nTimeOffset = 0;
 
 /**

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -104,7 +104,34 @@ private:
     uint64_t totalTxSize; //! sum of all mempool tx' byte sizes
 
 public:
-    mutable CCriticalSection cs;
+    /**
+     * This mutex needs to be locked when accessing `mapTx` or other members
+     * that are guarded by it.
+     *
+     * @par Consistency guarantees
+     *
+     * By design, it is guaranteed that:
+     *
+     * 1. Locking both `cs_main` and `mempool.cs` will give a view of mempool
+     *    that is consistent with current chain tip (`::ChainActive()` and
+     *    `CoinsTip()`) and is fully populated. Fully populated means that if the
+     *    current active chain is missing transactions that were present in a
+     *    previously active chain, all the missing transactions will have been
+     *    re-added to the mempool and should be present if they meet size and
+     *    consistency constraints.
+     *
+     * 2. Locking `mempool.cs` without `cs_main` will give a view of a mempool
+     *    consistent with some chain that was active since `cs_main` was last
+     *    locked, and that is fully populated as described above. It is ok for
+     *    code that only needs to query or remove transactions from the mempool
+     *    to lock just `mempool.cs` without `cs_main`.
+     *
+     * To provide these guarantees, it is necessary to lock both `cs_main` and
+     * `mempool.cs` whenever adding transactions to the mempool and whenever
+     * changing the chain tip. It's necessary to keep both mutexes locked until
+     * the mempool is consistent with the new chain tip and fully populated.
+     */
+    mutable RecursiveMutex cs;
     std::map<uint256, CTxMemPoolEntry> mapTx;
     std::map<COutPoint, CInPoint> mapNextTx;
     std::map<uint256, std::pair<double, CAmount> > mapDeltas;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -136,7 +136,7 @@ bool fLogIPs = false;
 volatile bool fReopenDebugLog = false;
 
 /** Init OpenSSL library multithreading support */
-static CCriticalSection** ppmutexOpenSSL;
+static RecursiveMutex** ppmutexOpenSSL;
 void locking_callback(int mode, int i, const char* file, int line) NO_THREAD_SAFETY_ANALYSIS
 {
     if (mode & CRYPTO_LOCK) {
@@ -153,9 +153,9 @@ public:
     CInit()
     {
         // Init OpenSSL library multithreading support
-        ppmutexOpenSSL = (CCriticalSection**)OPENSSL_malloc(CRYPTO_num_locks() * sizeof(CCriticalSection*));
+        ppmutexOpenSSL = (RecursiveMutex**)OPENSSL_malloc(CRYPTO_num_locks() * sizeof(RecursiveMutex*));
         for (int i = 0; i < CRYPTO_num_locks(); i++)
-            ppmutexOpenSSL[i] = new CCriticalSection();
+            ppmutexOpenSSL[i] = new RecursiveMutex();
         CRYPTO_set_locking_callback(locking_callback);
 
         // OpenSSL can optionally load a config file which lists optional loadable modules and engines.
@@ -471,7 +471,7 @@ boost::filesystem::path GetDefaultDataDir()
 
 static boost::filesystem::path pathCached;
 static boost::filesystem::path pathCachedNetSpecific;
-static CCriticalSection csPathCached;
+static RecursiveMutex csPathCached;
 
 const boost::filesystem::path& GetDataDir(bool fNetSpecific)
 {

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -42,7 +42,7 @@ private:
     void EnvShutdown();
 
 public:
-    mutable CCriticalSection cs_db;
+    mutable RecursiveMutex cs_db;
     DbEnv dbenv;
     std::map<std::string, int> mapFileUseCount;
     std::map<std::string, Db*> mapDb;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -31,7 +31,7 @@ using namespace boost;
 using namespace boost::assign;
 
 int64_t nWalletUnlockTime;
-static CCriticalSection cs_nWalletUnlockTime;
+static RecursiveMutex cs_nWalletUnlockTime;
 
 std::string HelpRequiringPassphrase()
 {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -282,7 +282,7 @@ public:
      *      fFileBacked (immutable after instantiation)
      *      strWalletFile (immutable after instantiation)
      */
-    mutable CCriticalSection cs_wallet;
+    mutable RecursiveMutex cs_wallet;
 
     bool fFileBacked;
     bool fWalletUnlockAnonymizeOnly;


### PR DESCRIPTION
> Effort to bring us up up-to-date with upstream's sync.h/cpp sources.
> 
> This PR contains:
> 
> * A complete move from CCriticalSection to identical RecursiveMutex (both are AnnotatedMixinstd::recursive_mutex).
> * Using WAIT_LOCK macro instead of WaitableLock.

from https://github.com/PIVX-Project/PIVX/pull/1337