### PR TITLE
[Upstream][Refactor] move nReserveBalance from main to wallet

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -885,12 +885,14 @@ bool AppInit2(bool isDaemon)
             LogPrintf("AppInit2 : parameter interaction: -enableswifttx=false -> setting -nSwiftTXDepth=0\n");
     }
 
+#ifdef ENABLE_WALLET
     if (mapArgs.count("-reservebalance")) {
         if (!ParseMoney(mapArgs["-reservebalance"], nReserveBalance)) {
             InitError(_("Invalid amount for -reservebalance=<amount>"));
             return false;
         }
     }
+#endif
 
     // Make sure enough file descriptors are available
     int nBind = std::max((int)mapArgs.count("-bind") + (int)mapArgs.count("-whitebind"), 1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,7 +90,6 @@ unsigned int nCoinCacheSize = 5000;
 int64_t nMaxTipAge = DEFAULT_MAX_TIP_AGE;
 
 unsigned int nStakeMinAge = 60 * 60;
-int64_t nReserveBalance = 0;
 
 const int MIN_RING_SIZE = 11;
 const int MAX_RING_SIZE = 15;

--- a/src/main.h
+++ b/src/main.h
@@ -163,7 +163,7 @@ extern unsigned int nStakeMinAge;
 extern int64_t nLastCoinStakeSearchInterval;
 //extern int64_t nConsolidationTime;
 extern int64_t nLastCoinStakeSearchTime;
-extern int64_t nReserveBalance;
+
 extern const int MIN_RING_SIZE;
 extern const int MAX_RING_SIZE;
 extern const int MAX_TX_INPUTS;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -51,7 +51,8 @@ bool bSpendZeroConfChange = true;
 bool bdisableSystemnotifications = false; // Those bubbles can be annoying and slow down the UI when you get lots of trx
 bool fSendFreeTransactions = false;
 bool fPayAtLeastCustomFee = true;
-int64_t nStartupTime = GetTime(); //!< Client startup time for use with automint
+int64_t nStartupTime = GetTime();
+int64_t nReserveBalance = 0;
 
 #include "uint256.h"
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -55,6 +55,7 @@ extern bool bSpendZeroConfChange;
 extern bool bdisableSystemnotifications;
 extern bool fSendFreeTransactions;
 extern bool fPayAtLeastCustomFee;
+extern int64_t nReserveBalance;
 
 //! -paytxfee default
 static const CAmount DEFAULT_TRANSACTION_FEE = 0.1 * COIN;//


### PR DESCRIPTION
> Straightforward.

from https://github.com/PIVX-Project/PIVX/pull/1366

It was closed as they no longer support Reserve Balance. We still do, so this makes sense.