### PR TITLE
[Upstream][GUI][Model] Save cache BlockIndex tip in the model

### DIFF
--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -42,7 +42,7 @@ bool CheckBlock(int nHeight, const uint256& hash, bool fMatchesCheckpoint)
 }
 
 //! Guess how far we are in the verification process at the given block index
-double GuessVerificationProgress(CBlockIndex* pindex, bool fSigchecks)
+double GuessVerificationProgress(const CBlockIndex* pindex, bool fSigchecks)
 {
     if (pindex == NULL)
         return 0.0;

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -35,7 +35,7 @@ int GetTotalBlocksEstimate();
 //! Returns last CBlockIndex* in mapBlockIndex that is a checkpoint
 CBlockIndex* GetLastCheckpoint();
 
-double GuessVerificationProgress(CBlockIndex* pindex, bool fSigchecks = true);
+double GuessVerificationProgress(const CBlockIndex* pindex, bool fSigchecks = true);
 
 extern bool fEnabled;
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -18,6 +18,7 @@
 #include "masternode-sync.h"
 #include "masternodeman.h"
 #include "net.h"
+#include "netbase.h"
 #include "guiinterface.h"
 #include "util.h"
 
@@ -35,7 +36,7 @@ ClientModel::ClientModel(OptionsModel* optionsModel, QObject* parent) : QObject(
                                                                         optionsModel(optionsModel),
                                                                         peerTableModel(0),
                                                                         banTableModel(0),
-                                                                        cachedNumBlocks(0),
+                                                                        cacheTip(nullptr),
                                                                         cachedMasternodeCountString(""),
                                                                         cachedReindexing(0), cachedImporting(0),
                                                                         numBlocksAtStartup(-1), pollTimer(0)
@@ -84,8 +85,7 @@ QString ClientModel::getMasternodeCountString() const
 
 int ClientModel::getNumBlocks() const
 {
-    LOCK(cs_main);
-    return chainActive.Height();
+    return cacheTip == nullptr ? 0 : cacheTip->nHeight;
 }
 
 int ClientModel::getNumBlocksAtStartup()
@@ -106,20 +106,14 @@ quint64 ClientModel::getTotalBytesSent() const
 
 QDateTime ClientModel::getLastBlockDate() const
 {
-    LOCK(cs_main);
-    if (chainActive.Tip())
-        return QDateTime::fromTime_t(chainActive.Tip()->GetBlockTime());
-    else
-        return QDateTime::fromTime_t(Params().GenesisBlock().GetBlockTime()); // Genesis block's time of current network
+    const int nTime = (cacheTip == nullptr ? Params().GenesisBlock().GetBlockTime() : cacheTip->GetBlockTime());
+    return QDateTime::fromTime_t(nTime);
 }
 
 QString ClientModel::getLastBlockHash() const
 {
-    LOCK(cs_main);
-    if (chainActive.Tip())
-        return QString::fromStdString(chainActive.Tip()->GetBlockHash().ToString());
-    else
-        return QString::fromStdString(Params().GenesisBlock().GetHash().ToString()); // Genesis block's hash of current network
+    const uint256& nHash = (cacheTip == nullptr ? Params().GenesisBlock().GetHash() : cacheTip->GetBlockHash());
+    return QString::fromStdString(nHash.GetHex());
 }
 
 int ClientModel::getChainHeight() const
@@ -133,8 +127,7 @@ int ClientModel::getChainHeight() const
 
 double ClientModel::getVerificationProgress() const
 {
-    LOCK(cs_main);
-    return Checkpoints::GuessVerificationProgress(chainActive.Tip());
+    return Checkpoints::GuessVerificationProgress(cacheTip);
 }
 
 void ClientModel::updateTimer()
@@ -256,11 +249,10 @@ static void BlockTipChanged(ClientModel *clientmodel, bool initialSync, const CB
     // if we are in-sync, update the UI regardless of last update time
     if (!initialSync || now - nLastBlockTipUpdateNotification > MODEL_UPDATE_DELAY) {
         //pass a async signal to the UI thread
-        int newHeight = pIndex->nHeight;
-        clientmodel->setCacheNumBlocks(newHeight);
+        clientmodel->setCacheTip(pIndex);
         clientmodel->setCacheImporting(fImporting);
         clientmodel->setCacheReindexing(fReindex);
-        Q_EMIT clientmodel->numBlocksChanged(newHeight);
+        Q_EMIT clientmodel->numBlocksChanged(pIndex->nHeight);
         nLastBlockTipUpdateNotification = now;
     }
 }

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -9,6 +9,7 @@
 #define BITCOIN_QT_CLIENTMODEL_H
 
 #include "uint256.h"
+#include "chain.h"
 #include <QObject>
 #include <QDateTime>
 
@@ -54,18 +55,18 @@ public:
 
     //! Return number of connections, default is in- and outbound (total)
     int getNumConnections(unsigned int flags = CONNECTIONS_ALL) const;
-    QString getMasternodeCountString() const;
-    int getNumBlocks() const;
     int getNumBlocksAtStartup();
+    QString getMasternodeCountString() const;
+
+    // from cached block index
+    int getNumBlocks() const;
+    QDateTime getLastBlockDate() const;
+    QString getLastBlockHash() const;
+    int getChainHeight() const;
+    double getVerificationProgress() const;
 
     quint64 getTotalBytesRecv() const;
     quint64 getTotalBytesSent() const;
-
-    double getVerificationProgress() const;
-    QDateTime getLastBlockDate() const;
-    int getChainHeight() const;
-
-    QString getLastBlockHash() const;
 
     //! Return true if core is doing initial block download
     bool inInitialBlockDownload() const;
@@ -81,7 +82,7 @@ public:
     QString formatClientStartupTime() const;
     QString dataDir() const;
 
-    void setCacheNumBlocks(int blockNum) { cachedNumBlocks = blockNum; };
+    void setCacheTip(const CBlockIndex* const tip) { cacheTip = tip; };
     void setCacheReindexing(bool reindex) { cachedReindexing = reindex; };
     void setCacheImporting(bool import) { cachedImporting = import; };
 
@@ -90,7 +91,7 @@ private:
     PeerTableModel* peerTableModel;
     BanTableModel *banTableModel;
 
-    int cachedNumBlocks;
+    const CBlockIndex* cacheTip;
     QString cachedMasternodeCountString;
     bool cachedReindexing;
     bool cachedImporting;


### PR DESCRIPTION
first commit was required for GuessVerificationProgress const and is from: https://github.com/PIVX-Project/PIVX/commit/80753f9bf591367960f8a71d788633dde1c3a3ac

> **Probelm**: GUI client model requires calls to `chainActive` (thus locking the main UI thread) for the following functions:
> 
> * getNumBlocks
> * getLastBlockDate
> * getLastBlockHash
> * getVerificationProgress
> 
> **Fix**: use the `NotifyBlockTip` core signal to update a cached tip blockindex in `BlockTipChanged`, and rely on this object for the aforementioned functions.
> 

from https://github.com/PIVX-Project/PIVX/pull/1408