### PR TITLE
[GUI] "Loading Blocks" statuses added to Network Status and Overview

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1159,8 +1159,9 @@ void BitcoinGUI::setNumBlocks(int count)
         tooltip += QString("<br>");
         tooltip += tr("Transactions after this will not yet be visible.");
     }
-
-    if (IsInitialBlockDownload()) {
+    if (count == 0) {
+        blockCount->setText(tr("Loading Blocks..."));
+    } else if (IsInitialBlockDownload()) {
         blockCount->setText(tr("Syncing Blocks..."));
     } else {
         blockCount->setText(tr("%n Blocks", "", count));

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -156,7 +156,7 @@
            <item>
             <widget class="QLabel" name="labelBlockStatus">
              <property name="text">
-              <string notr="true">(syncing)</string>
+              <string notr="true">(loading)</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignHCenter|Qt::AlignTop</set>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -327,8 +327,14 @@ void OverviewPage::showBlockSync(bool fShow)
 
     isSyncingBlocks = fShow;
 
-    ui->labelBlockCurrent->setText(QString::number(clientModel->getNumBlocks()));
-    if (isSyncingBlocks){
+    int count = clientModel->getNumBlocks();
+    ui->labelBlockCurrent->setText(QString::number(count));
+
+    if (count == 0 & isSyncingBlocks){
+        ui->labelBlockStatus->setText("(loading)");
+        ui->labelBlockStatus->setToolTip("The displayed information may be out of date. Your wallet automatically synchronizes with the DAPS network after a connection is established, but this process has not completed yet.");
+        ui->labelBlockCurrent->setAlignment((Qt::AlignRight|Qt::AlignVCenter));
+    } else if (isSyncingBlocks){
         ui->labelBlockStatus->setText("(syncing)");
         ui->labelBlockStatus->setToolTip("The displayed information may be out of date. Your wallet automatically synchronizes with the DAPS network after a connection is established, but this process has not completed yet.");
         ui->labelBlockCurrent->setAlignment((Qt::AlignRight|Qt::AlignVCenter));


### PR DESCRIPTION
With #116  we are able to add better status info to Network Status and Overview, screenshots below:
- Add "Loading Blocks" status text
- Add "(loading)" to sync circle on Overview page

![image](https://user-images.githubusercontent.com/2319897/76907812-8fbdc200-687d-11ea-88d5-b7ae647749c7.png)
