### PR TITLE
[UI] Make "Data Directory" and "Last block hash" details selectable

### DIFF
--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -32,6 +32,9 @@
          <property name="text">
           <string>N/A</string>
          </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
         </widget>
        </item>
        <item row="0" column="0">
@@ -389,6 +392,9 @@
         <widget class="QLabel" name="lastBlockHash">
          <property name="text">
           <string>N/A</string>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
For some reason the text of these items were not able to be selected. This fixes this minor issue. Useful if the user wants to copy/paste the Data directory or last block hash for troubleshooting or other tasks.

![image](https://user-images.githubusercontent.com/2319897/77010313-ea1f5700-693f-11ea-9752-274bcce3b083.png)
