### PR TITLE
[Upstream][Qt] Define QT_NO_KEYWORDS

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -395,7 +395,7 @@ RES_MOVIES = $(wildcard $(srcdir)/qt/res/movies/spinner-*.png)
 BITCOIN_RC = qt/res/dapscoin-qt-res.rc
 
 BITCOIN_QT_INCLUDES = -I$(builddir)/qt -I$(srcdir)/qt -I$(srcdir)/qt/forms \
-  -I$(builddir)/qt/forms
+  -I$(builddir)/qt/forms -DQT_NO_KEYWORDS
 
 qt_libbitcoinqt_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BITCOIN_QT_INCLUDES) \
   $(QT_INCLUDES) $(QT_DBUS_INCLUDES) $(PROTOBUF_CFLAGS) $(QR_CFLAGS)

--- a/src/qt/2faconfirmdialog.h
+++ b/src/qt/2faconfirmdialog.h
@@ -16,7 +16,7 @@ public:
     explicit TwoFAConfirmDialog(QWidget *parent = 0);
     ~TwoFAConfirmDialog();
 
-private slots:
+private Q_SLOTS:
     void on_acceptCode();
     void codeChanged(const QString & txt);
 

--- a/src/qt/2fadialog.h
+++ b/src/qt/2fadialog.h
@@ -16,7 +16,7 @@ public:
     explicit TwoFADialog(QWidget *parent = 0);
     ~TwoFADialog();
 
-private slots:
+private Q_SLOTS:
     void on_acceptCode();
     void codeChanged(const QString & txt);
 

--- a/src/qt/2faqrdialog.h
+++ b/src/qt/2faqrdialog.h
@@ -23,7 +23,7 @@ public:
 private:
     void update();
 
-private slots:
+private Q_SLOTS:
     void on_btnCopyURI_clicked();
 
 

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -243,7 +243,7 @@ void AddressBookPage::done(int retval)
     // Figure out which address was selected, and return it
     QModelIndexList indexes = table->selectionModel()->selectedRows(AddressTableModel::Address);
 
-    foreach (QModelIndex index, indexes) {
+   Q_FOREACH (QModelIndex index, indexes) {
         QVariant address = table->model()->data(index);
         returnValue = address.toString();
     }

--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -46,7 +46,7 @@ public:
     void setModel(AddressTableModel* model);
     const QString& getReturnValue() const { return returnValue; }
 
-public slots:
+public Q_SLOTS:
     void done(int retval);
 
 private:
@@ -60,7 +60,7 @@ private:
     QAction* deleteAction; // to be able to explicitly disable it
     QString newAddressToSelect;
 
-private slots:
+private Q_SLOTS:
     /** Delete currently selected address entry */
     void on_deleteAddress_clicked();
     /** Create a new address for receiving coins and / or add a new address book entry */
@@ -81,7 +81,7 @@ private slots:
     /** New entry/entries were added to address table */
     void selectNewAddress(const QModelIndex& parent, int begin, int /*end*/);
 
-signals:
+Q_SIGNALS:
     void sendCoins(QString addr);
 };
 

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -423,5 +423,5 @@ int AddressTableModel::lookupAddress(const QString& address) const
 
 void AddressTableModel::emitDataChanged(int idx)
 {
-    emit dataChanged(index(idx, 0, QModelIndex()), index(idx, columns.length() - 1, QModelIndex()));
+    Q_EMIT dataChanged(index(idx, 0, QModelIndex()), index(idx, columns.length() - 1, QModelIndex()));
 }

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -84,7 +84,7 @@ private:
     /** Notify listeners that data changed. */
     void emitDataChanged(int index);
 
-public slots:
+public Q_SLOTS:
     /* Update address list from core.
      */
     void updateEntry(const QString& address, const QString& label, bool isMine, const QString& purpose, int status);

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -55,7 +55,7 @@ private:
     Context context;
     bool fCapsLock;
 
-private slots:
+private Q_SLOTS:
     void textChanged();
 
 protected:

--- a/src/qt/bip38tooldialog.h
+++ b/src/qt/bip38tooldialog.h
@@ -36,7 +36,7 @@ private:
     Ui::Bip38ToolDialog* ui;
     WalletModel* model;
 
-private slots:
+private Q_SLOTS:
     /* encrypt key */
     void on_addressBookButton_ENC_clicked();
     void on_pasteButton_ENC_clicked();

--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -59,7 +59,7 @@ public:
     void setValue(const CAmount& value)
     {
         lineEdit()->setText(BitcoinUnits::format(currentUnit, value, false, BitcoinUnits::separatorAlways));
-        emit valueChanged();
+        Q_EMIT valueChanged();
     }
 
     void stepBy(int steps)
@@ -173,7 +173,7 @@ protected:
         return rv;
     }
 
-signals:
+Q_SIGNALS:
     void valueChanged();
 };
 

--- a/src/qt/bitcoinamountfield.h
+++ b/src/qt/bitcoinamountfield.h
@@ -56,7 +56,7 @@ public:
     */
     QWidget* setupTabChain(QWidget* prev);
 
-signals:
+Q_SIGNALS:
     void valueChanged();
 
 protected:
@@ -67,7 +67,7 @@ private:
     AmountSpinBox* amount;
     QValueComboBox* unit;
 
-private slots:
+private Q_SLOTS:
     void unitChanged(int idx);
 };
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -978,7 +978,7 @@ void BitcoinGUI::openClicked()
 {
     OpenURIDialog dlg(this);
     if (dlg.exec()) {
-        emit receivedURI(dlg.getURI());
+        Q_EMIT receivedURI(dlg.getURI());
     }
 }
 
@@ -1292,8 +1292,8 @@ bool BitcoinGUI::eventFilter(QObject *obj, QEvent *event)
 void BitcoinGUI::dropEvent(QDropEvent* event)
 {
     if (event->mimeData()->hasUrls()) {
-        foreach (const QUrl& uri, event->mimeData()->urls()) {
-            emit receivedURI(uri.toString());
+       Q_FOREACH (const QUrl& uri, event->mimeData()->urls()) {
+            Q_EMIT receivedURI(uri.toString());
         }
     }
     event->acceptProposedAction();
@@ -1483,7 +1483,7 @@ void BitcoinGUI::unsubscribeFromCoreSignals()
 void BitcoinGUI::handleRestart(QStringList args)
 {
     if (!ShutdownRequested())
-        emit requestedRestart(args);
+        Q_EMIT requestedRestart(args);
 }
 
 UnitDisplayStatusBarControl::UnitDisplayStatusBarControl() : optionsModel(0),
@@ -1504,7 +1504,7 @@ void UnitDisplayStatusBarControl::createContextMenu()
 {
     menu = new QMenu(this);
     menu->setAttribute(Qt::WA_DeleteOnClose);
-    foreach (BitcoinUnits::Unit u, BitcoinUnits::availableUnits()) {
+   Q_FOREACH (BitcoinUnits::Unit u, BitcoinUnits::availableUnits()) {
         QAction* menuAction = new QAction(QString(BitcoinUnits::name(u)), this);
         menuAction->setData(QVariant(u));
         menu->addAction(menuAction);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -180,13 +180,13 @@ private:
     /** Disconnect core signals from GUI client */
     void unsubscribeFromCoreSignals();
 
-signals:
+Q_SIGNALS:
     /** Signal raised when a URI was entered or dragged to the GUI */
     void receivedURI(const QString& uri);
     /** Restart handling */
     void requestedRestart(QStringList args);
 
-public slots:
+public Q_SLOTS:
     /** Set number of connections shown in the UI */
     void setNumConnections(int count);
     /** Set number of blocks shown in the UI */
@@ -219,7 +219,7 @@ public slots:
     void incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address, const QString& confirmations);
 #endif // ENABLE_WALLET
 
-private slots:
+private Q_SLOTS:
 #ifdef ENABLE_WALLET
     /** Switch to overview (home) page */
     void gotoOverviewPage();
@@ -310,7 +310,7 @@ private:
     /** Creates context menu, its actions, and wires up all the relevant signals for mouse events. */
     void createContextMenu();
 
-private slots:
+private Q_SLOTS:
     /** When Display Units are changed on OptionsModel it will refresh the display text of the control on the status bar */
     void updateDisplayUnit(int newUnits);
     /** Tells underlying optionsModel to update its current display unit. */

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -135,7 +135,7 @@ void ClientModel::updateTimer()
     // Get required lock upfront. This avoids the GUI from getting stuck on
     // periodical polls if the core is holding the locks for a longer time -
     // for example, during a wallet rescan.
-    emit bytesChanged(getTotalBytesRecv(), getTotalBytesSent());
+    Q_EMIT bytesChanged(getTotalBytesRecv(), getTotalBytesSent());
 }
 
 void ClientModel::updateMnTimer()
@@ -151,18 +151,18 @@ void ClientModel::updateMnTimer()
     if (cachedMasternodeCountString != newMasternodeCountString) {
         cachedMasternodeCountString = newMasternodeCountString;
 
-        emit strMasternodesChanged(cachedMasternodeCountString);
+        Q_EMIT strMasternodesChanged(cachedMasternodeCountString);
     }
 }
 
 void ClientModel::updateNumConnections(int numConnections)
 {
-    emit numConnectionsChanged(numConnections);
+    Q_EMIT numConnectionsChanged(numConnections);
 }
 
 void ClientModel::updateAlert()
 {
-    emit alertsChanged(getStatusBarWarnings());
+    Q_EMIT alertsChanged(getStatusBarWarnings());
 }
 
 bool ClientModel::inInitialBlockDownload() const

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -104,7 +104,7 @@ private:
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
 
-signals:
+Q_SIGNALS:
     void numConnectionsChanged(int count);
     void numBlocksChanged(int count);
     void strMasternodesChanged(const QString& strMasternodes);
@@ -117,7 +117,7 @@ signals:
     // Show progress dialog e.g. for verifychain
     void showProgress(const QString& title, int nProgress);
 
-public slots:
+public Q_SLOTS:
     void updateTimer();
     void updateMnTimer();
     void updateNumConnections(int numConnections);

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -529,7 +529,7 @@ void CoinControlDialog::updateLabels(WalletModel* model, QDialog* dialog)
     CAmount nPayAmount = 0;
     bool fDust = false;
     CMutableTransaction txDummy;
-    foreach (const CAmount& amount, CoinControlDialog::payAmounts) {
+   Q_FOREACH (const CAmount& amount, CoinControlDialog::payAmounts) {
         nPayAmount += amount;
 
         if (amount > 0) {

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -87,7 +87,7 @@ private:
 
     friend class CCoinControlWidgetItem;
 
-private slots:
+private Q_SLOTS:
     void showMenu(const QPoint&);
     void copyAmount();
     void copyLabel();

--- a/src/qt/dapscoin.cpp
+++ b/src/qt/dapscoin.cpp
@@ -175,13 +175,13 @@ class BitcoinCore : public QObject
 public:
     explicit BitcoinCore();
 
-public slots:
+public Q_SLOTS:
     void initialize();
     void registerNodeSignal();
     void shutdown();
     void restart(QStringList args);
 
-signals:
+Q_SIGNALS:
     void initializeResult(int retval);
     void shutdownResult(int retval);
     void runawayException(const QString& message);
@@ -226,13 +226,13 @@ public:
     /// Get window identifier of QMainWindow (BitcoinGUI)
     WId getMainWinId() const;
 
-public slots:
+public Q_SLOTS:
     void initializeResult(int retval);
     void shutdownResult(int retval);
     /// Handle runaway exceptions. Shows a message box with the problem and quits the program.
     void handleRunawayException(const QString& message);
 
-signals:
+Q_SIGNALS:
     void requestedInitialize();
     void requestedRegisterNodeSignal();
     void requestedRestart(QStringList args);
@@ -264,7 +264,7 @@ BitcoinCore::BitcoinCore() : QObject()
 void BitcoinCore::handleRunawayException(std::exception* e)
 {
     PrintExceptionContinue(e, "Runaway exception");
-    emit runawayException(QString::fromStdString(strMiscWarning));
+    Q_EMIT runawayException(QString::fromStdString(strMiscWarning));
 }
 
 void BitcoinCore::registerNodeSignal()
@@ -279,7 +279,7 @@ void BitcoinCore::initialize()
     try {
         qDebug() << __func__ << ": Running AppInit2 in thread";
         int rv = AppInit2(false);
-        emit initializeResult(rv);
+        Q_EMIT initializeResult(rv);
     } catch (std::exception& e) {
         handleRunawayException(&e);
     } catch (...) {
@@ -296,7 +296,7 @@ void BitcoinCore::restart(QStringList args)
             Interrupt();
             PrepareShutdown();
             qDebug() << __func__ << ": Shutdown finished";
-            emit shutdownResult(1);
+            Q_EMIT shutdownResult(1);
             CExplicitNetCleanup::callCleanup();
             QProcess::startDetached(QApplication::applicationFilePath(), args);
             qDebug() << __func__ << ": Restart initiated...";
@@ -316,7 +316,7 @@ void BitcoinCore::shutdown()
         Interrupt();
         Shutdown();
         qDebug() << __func__ << ": Shutdown finished";
-        emit shutdownResult(1);
+        Q_EMIT shutdownResult(1);
     } catch (std::exception& e) {
         handleRunawayException(&e);
     } catch (...) {
@@ -343,7 +343,7 @@ BitcoinApplication::~BitcoinApplication()
 {
     if (coreThread) {
         qDebug() << __func__ << ": Stopping thread";
-        emit stopThread();
+        Q_EMIT stopThread();
         coreThread->wait();
         qDebug() << __func__ << ": Stopped thread";
     }
@@ -428,7 +428,7 @@ void BitcoinApplication::requestInitialize()
 {
     qDebug() << __func__ << ": Requesting initialize";
     startThread();
-    emit requestedInitialize();
+    Q_EMIT requestedInitialize();
 }
 
 void BitcoinApplication::requestShutdown()
@@ -451,7 +451,7 @@ void BitcoinApplication::requestShutdown()
     ShutdownWindow::showShutdownWindow(window);
 
     // Request shutdown from core thread
-    emit requestedShutdown();
+    Q_EMIT requestedShutdown();
 }
 
 void BitcoinApplication::initializeResult(int retval)
@@ -495,7 +495,7 @@ void BitcoinApplication::initializeResult(int retval)
         } else {
             window->show();
         }
-        emit splashFinished(window);
+        Q_EMIT splashFinished(window);
 
 #ifdef ENABLE_WALLET
         // Now that initialization/startup is done, process any command-line
@@ -514,7 +514,7 @@ void BitcoinApplication::initializeResult(int retval)
                         pwalletMain->WriteStakingStatus(false);
                     }
                 }
-                emit requestedRegisterNodeSignal();
+                Q_EMIT requestedRegisterNodeSignal();
             }
             if (!walletUnlocked && walletModel->getEncryptionStatus() == WalletModel::Unencrypted) {
                 EncryptDialog dlg;
@@ -523,7 +523,7 @@ void BitcoinApplication::initializeResult(int retval)
                 dlg.setStyleSheet(GUIUtil::loadStyleSheet());
                 dlg.exec();
 
-                emit requestedRegisterNodeSignal();
+                Q_EMIT requestedRegisterNodeSignal();
                 walletModel->updateStatus();
             }
         }

--- a/src/qt/editaddressdialog.h
+++ b/src/qt/editaddressdialog.h
@@ -41,7 +41,7 @@ public:
     QString getAddress() const;
     void setAddress(const QString& address);
 
-public slots:
+public Q_SLOTS:
     void accept();
 
 private:

--- a/src/qt/encryptdialog.h
+++ b/src/qt/encryptdialog.h
@@ -19,7 +19,7 @@ public:
     void setModel(WalletModel* model);
     bool matchNewPasswords();
 
-private slots:
+private Q_SLOTS:
 	void on_btnCancel();
 	void on_acceptPassphrase();
 	void validateNewPass();

--- a/src/qt/entermnemonics.h
+++ b/src/qt/entermnemonics.h
@@ -17,7 +17,7 @@ class EnterMnemonics : public QDialog
 public:
     explicit EnterMnemonics(QWidget *parent = 0);
     ~EnterMnemonics();
-private slots:
+private Q_SLOTS:
     void on_next();
 
 private:

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -839,7 +839,7 @@ QString loadStyleSheet()
 
 void refreshStyleSheet(){
     qApp->setStyleSheet(GUIUtil::loadStyleSheet());
-    foreach (QWidget *widget, QApplication::topLevelWidgets()){
+   Q_FOREACH (QWidget *widget, QApplication::topLevelWidgets()){
         widget->setStyleSheet(GUIUtil::loadStyleSheet());
         widget->update();
     }

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -197,7 +197,7 @@ private:
     void setViewHeaderResizeMode(int logicalIndex, QHeaderView::ResizeMode resizeMode);
     void resizeColumn(int nColumnIndex, int width);
 
-private slots:
+private Q_SLOTS:
     void on_sectionResized(int logicalIndex, int oldSize, int newSize);
     void on_geometriesChanged();
 };

--- a/src/qt/historypage.h
+++ b/src/qt/historypage.h
@@ -43,7 +43,7 @@ public:
     ~HistoryPage();
     void setModel(WalletModel* model);
 
-public slots:
+public Q_SLOTS:
     void updateFilter();
     void syncTime(QDateTimeEdit* calendar, QTimeEdit* clock);
 
@@ -67,7 +67,7 @@ private:
     void updateTableData(CWallet *wallet);
     void updateAddressBookData(CWallet *wallet);
 
-public slots:
+public Q_SLOTS:
     void on_cellClicked(int row, int column);
     void updateTableData();
 };

--- a/src/qt/importorcreate.h
+++ b/src/qt/importorcreate.h
@@ -18,7 +18,7 @@ public:
     explicit ImportOrCreate(QWidget *parent = 0);
     ~ImportOrCreate();
     bool willRecover = false;
-private slots:
+private Q_SLOTS:
     void on_next();
 
 private:

--- a/src/qt/include/qgoogleauth/base32.h
+++ b/src/qt/include/qgoogleauth/base32.h
@@ -10,9 +10,9 @@ public:
     explicit Base32(QObject *parent = 0);
     static int base32_decode(const quint8 *encoded, quint8 *result, int bufSize);
     
-signals:
+Q_SIGNALS:
     
-public slots:
+public Q_SLOTS:
     
 };
 

--- a/src/qt/include/qgoogleauth/hmac.h
+++ b/src/qt/include/qgoogleauth/hmac.h
@@ -10,9 +10,9 @@ public:
     explicit HMAC(QObject *parent = 0);
     static QByteArray hmacSha1(QByteArray key, QByteArray baseString);
     
-signals:
+Q_SIGNALS:
     
-public slots:
+public Q_SLOTS:
     
 };
 

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -44,10 +44,10 @@ public:
         ST_ERROR
     };
 
-public slots:
+public Q_SLOTS:
     void check();
 
-signals:
+Q_SIGNALS:
     void reply(int status, const QString& message, quint64 available);
 
 private:
@@ -100,7 +100,7 @@ void FreespaceChecker::check()
         replyStatus = ST_ERROR;
         replyMessage = tr("Cannot create data directory here.");
     }
-    emit reply(replyStatus, replyMessage, freeBytesAvailable);
+    Q_EMIT reply(replyStatus, replyMessage, freeBytesAvailable);
 }
 
 
@@ -118,7 +118,7 @@ Intro::~Intro()
 {
     delete ui;
     /* Ensure thread is finished before it is deleted */
-    emit stopThread();
+    Q_EMIT stopThread();
     thread->wait();
 }
 
@@ -267,7 +267,7 @@ void Intro::checkPath(const QString& dataDir)
     pathToCheck = dataDir;
     if (!signalled) {
         signalled = true;
-        emit requestCheck();
+        Q_EMIT requestCheck();
     }
     mutex.unlock();
 }

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -49,14 +49,14 @@ public:
      */
     static QString getDefaultDataDirectory();
 
-signals:
+Q_SIGNALS:
     void requestCheck();
     void stopThread();
 
-public slots:
+public Q_SLOTS:
     void setStatus(int status, const QString& message, quint64 bytesAvailable);
 
-private slots:
+private Q_SLOTS:
     void on_dataDirectory_textChanged(const QString& arg1);
     void on_ellipsisButton_clicked();
     void on_dataDirDefault_clicked();

--- a/src/qt/macdockiconhandler.h
+++ b/src/qt/macdockiconhandler.h
@@ -30,7 +30,7 @@ public:
     static void cleanup();
     void handleDockIconClickEvent();
 
-signals:
+Q_SIGNALS:
     void dockIconClicked();
 
 private:

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -121,5 +121,5 @@ void MacDockIconHandler::handleDockIconClickEvent()
         this->mainWindow->show();
     }
 
-    emit this->dockIconClicked();
+    Q_EMIT this->dockIconClicked();
 }

--- a/src/qt/multisenddialog.h
+++ b/src/qt/multisenddialog.h
@@ -21,7 +21,7 @@ public:
     void setModel(WalletModel* model);
     void setAddress(const QString& address);
     void setAddress(const QString& address, QLineEdit* addrEdit);
-private slots:
+private Q_SLOTS:
     void on_viewButton_clicked();
     void on_addButton_clicked();
     void on_deleteButton_clicked();

--- a/src/qt/multisigdialog.h
+++ b/src/qt/multisigdialog.h
@@ -32,7 +32,7 @@ public:
     void setModel(WalletModel* model);
     void updateCoinControl(CAmount nAmount, unsigned int nQuantity);
 
-public slots:
+public Q_SLOTS:
     void showTab(int index);
 
 private:
@@ -53,7 +53,7 @@ private:
     bool addMultisig(int m, std::vector<std::string> keys);
     bool isFullyVerified(CMutableTransaction& txToVerify);
 
-private slots:
+private Q_SLOTS:
    void deleteFrame();
    void pasteText();
    void commitMultisigTx();

--- a/src/qt/notificator.h
+++ b/src/qt/notificator.h
@@ -39,7 +39,7 @@ public:
         Critical     /**< An error occurred */
     };
 
-public slots:
+public Q_SLOTS:
     /** Show notification message.
        @param[in] cls    general message class
        @param[in] title  title shown with message

--- a/src/qt/openuridialog.h
+++ b/src/qt/openuridialog.h
@@ -22,10 +22,10 @@ public:
 
     QString getURI();
 
-protected slots:
+protected Q_SLOTS:
     void accept();
 
-private slots:
+private Q_SLOTS:
     void on_selectFileButton_clicked();
 
 private:

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -84,7 +84,7 @@ OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet) : QDialog(paren
     /* Language selector */
     QDir translations(":translations");
     ui->lang->addItem(QString("(") + tr("default") + QString(")"), QVariant(""));
-    foreach (const QString& langStr, translations.entryList()) {
+   Q_FOREACH (const QString& langStr, translations.entryList()) {
         QLocale locale(langStr);
 
         /** check if the locale name consists of 2 parts (language_country) */
@@ -303,7 +303,7 @@ bool OptionsDialog::eventFilter(QObject* object, QEvent* event)
 {
     if (event->type() == QEvent::FocusOut) {
         if (object == ui->proxyIp || object == ui->proxyPort) {
-            emit proxyIpChecks(ui->proxyIp, ui->proxyPort);
+            Q_EMIT proxyIpChecks(ui->proxyIp, ui->proxyPort);
         }
     }
     return QDialog::eventFilter(object, event);

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -35,7 +35,7 @@ public:
 protected:
     bool eventFilter(QObject* object, QEvent* event);
 
-private slots:
+private Q_SLOTS:
     /* enable OK button */
     void enableOkButton();
     /* disable OK button */
@@ -52,7 +52,7 @@ private slots:
     void clearStatusLabel();
     void doProxyIpChecks(QValidatedLineEdit* pUiProxyIp, QLineEdit* pUiProxyPort);
 
-signals:
+Q_SIGNALS:
     void proxyIpChecks(QValidatedLineEdit* pUiProxyIp, QLineEdit* pUiProxyPort);
 
 private:

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -313,12 +313,12 @@ bool OptionsModel::setData(const QModelIndex& index, const QVariant& value, int 
         case HideOrphans:
             fHideOrphans = value.toBool();
             settings.setValue("fHideOrphans", fHideOrphans);
-            emit hideOrphansChanged(fHideOrphans);
+            Q_EMIT hideOrphansChanged(fHideOrphans);
             break;
         case CoinControlFeatures:
             fCoinControlFeatures = value.toBool();
             settings.setValue("fCoinControlFeatures", fCoinControlFeatures);
-            emit coinControlFeaturesChanged(fCoinControlFeatures);
+            Q_EMIT coinControlFeaturesChanged(fCoinControlFeatures);
             break;
         case DatabaseCache:
             if (settings.value("nDatabaseCache") != value) {
@@ -343,7 +343,7 @@ bool OptionsModel::setData(const QModelIndex& index, const QVariant& value, int 
         }
     }
 
-    emit dataChanged(index, index);
+    Q_EMIT dataChanged(index, index);
 
     return successful;
 }
@@ -355,7 +355,7 @@ void OptionsModel::setDisplayUnit(const QVariant& value)
         QSettings settings;
         nDisplayUnit = value.toInt();
         settings.setValue("nDisplayUnit", nDisplayUnit);
-        emit displayUnitChanged(nDisplayUnit);
+        Q_EMIT displayUnitChanged(nDisplayUnit);
     }
 }
 

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -88,7 +88,7 @@ private:
     /// Add option to list of GUI options overridden through command line/config file
     void addOverriddenOption(const std::string& option);
 
-signals:
+Q_SIGNALS:
     void displayUnitChanged(int unit);
     void zeromintPercentageChanged(int);
     void preferredDenomChanged(int);

--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -70,7 +70,7 @@ OptionsPage::OptionsPage(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenu
             stkStatus = false;
             pwalletMain->walletStakingInProgress = false;
             pwalletMain->WriteStakingStatus(false);
-            //emit model->stakingStatusChanged(false);
+            //Q_EMIT model->stakingStatusChanged(false);
         } else {
             QString error;
             StakingStatusError stt = model->getStakingStatusError(error);
@@ -78,7 +78,7 @@ OptionsPage::OptionsPage(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenu
                 stkStatus = false;
                 pwalletMain->walletStakingInProgress = false;
                 pwalletMain->WriteStakingStatus(false);
-                //emit model->stakingStatusChanged(false);
+                //Q_EMIT model->stakingStatusChanged(false);
             }
         }
     }
@@ -221,7 +221,7 @@ void OptionsPage::on_pushButtonSave_clicked() {
     CWalletDB walletdb(pwalletMain->strWalletFile);
     walletdb.WriteReserveAmount(nReserveBalance / COIN);
 
-    emit model->stakingStatusChanged(nLastCoinStakeSearchInterval);
+    Q_EMIT model->stakingStatusChanged(nLastCoinStakeSearchInterval);
     ui->lineEditWithhold->setStyleSheet(GUIUtil::loadStyleSheet());
 	
     QString reserveBalance = ui->lineEditWithhold->text().trimmed();
@@ -239,7 +239,7 @@ void OptionsPage::on_pushButtonDisable_clicked() {
     CWalletDB walletdb(pwalletMain->strWalletFile);
     walletdb.WriteReserveAmount(0);
 
-    emit model->stakingStatusChanged(nLastCoinStakeSearchInterval);
+    Q_EMIT model->stakingStatusChanged(nLastCoinStakeSearchInterval);
     QMessageBox msgBox;
     msgBox.setWindowTitle("Reserve Balance Disabled");
     msgBox.setText("Reserve balance disabled.");
@@ -479,13 +479,13 @@ void OptionsPage::on_EnableStaking(ToggleButton* widget)
         	msgBox.exec();
         	widget->setState(false);
         	nLastCoinStakeSearchInterval = 0;
-        	emit model->stakingStatusChanged(false);
+        	Q_EMIT model->stakingStatusChanged(false);
         	pwalletMain->WriteStakingStatus(false);   
             return; 
         } 
         if (stt == StakingStatusError::STAKING_OK) {
             pwalletMain->WriteStakingStatus(true);
-            emit model->stakingStatusChanged(true);
+            Q_EMIT model->stakingStatusChanged(true);
             model->generateCoins(true, 1);
             pwalletMain->fCombineDust = true;
             pwalletMain->stakingMode = StakingMode::STAKING_WITH_CONSOLIDATION;
@@ -502,7 +502,7 @@ void OptionsPage::on_EnableStaking(ToggleButton* widget)
         reply = QMessageBox::question(this, "Staking Needs Consolidation", QString::fromStdString(errorMessage), QMessageBox::Yes|QMessageBox::No);
 		if (reply == QMessageBox::Yes) { 
             pwalletMain->WriteStakingStatus(true);
-            emit model->stakingStatusChanged(true);
+            Q_EMIT model->stakingStatusChanged(true);
             model->generateCoins(true, 1);
             pwalletMain->fCombineDust = true;
             pwalletMain->stakingMode = StakingMode::STAKING_WITH_CONSOLIDATION;
@@ -532,14 +532,14 @@ void OptionsPage::on_EnableStaking(ToggleButton* widget)
             pwalletMain->stakingMode = StakingMode::STOPPED;
             nLastCoinStakeSearchInterval = 0;
             model->generateCoins(false, 0);
-            emit model->stakingStatusChanged(false);
+            Q_EMIT model->stakingStatusChanged(false);
             pwalletMain->walletStakingInProgress = false;
             pwalletMain->WriteStakingStatus(false);
             return;
         }
         /* if (!error.length()) {
             pwalletMain->WriteStakingStatus(true);
-            emit model->stakingStatusChanged(true);
+            Q_EMIT model->stakingStatusChanged(true);
             model->generateCoins(true, 1);
         } else {
         	if (stt != StakingStatusError::UTXO_UNDER_THRESHOLD) {
@@ -552,7 +552,7 @@ void OptionsPage::on_EnableStaking(ToggleButton* widget)
         		msgBox.exec();
         		widget->setState(false);
         		nLastCoinStakeSearchInterval = 0;
-        		emit model->stakingStatusChanged(false);
+        		Q_EMIT model->stakingStatusChanged(false);
         		pwalletMain->WriteStakingStatus(false);
         	} else {
         		QMessageBox::StandardButton reply;
@@ -603,7 +603,7 @@ void OptionsPage::on_EnableStaking(ToggleButton* widget)
         		} else {
         			widget->setState(false);
         			nLastCoinStakeSearchInterval = 0;
-        			emit model->stakingStatusChanged(false);
+        			Q_EMIT model->stakingStatusChanged(false);
         			pwalletMain->WriteStakingStatus(false);
         		}
         	}
@@ -612,7 +612,7 @@ void OptionsPage::on_EnableStaking(ToggleButton* widget)
         pwalletMain->stakingMode = StakingMode::STOPPED;
         nLastCoinStakeSearchInterval = 0;
         model->generateCoins(false, 0);
-        emit model->stakingStatusChanged(false);
+        Q_EMIT model->stakingStatusChanged(false);
         pwalletMain->walletStakingInProgress = false;
         pwalletMain->WriteStakingStatus(false);
     }

--- a/src/qt/optionspage.h
+++ b/src/qt/optionspage.h
@@ -55,7 +55,7 @@ public:
     bool matchNewPasswords();
     StakingStatusError getStakingStatusError(QString&);
 
-public slots:
+public Q_SLOTS:
     void on_EnableStaking(ToggleButton*);
 
 protected:
@@ -77,7 +77,7 @@ private:
     QTimer* timerStakingToggleSync;
     void saveConsolidationSettingTime(bool);
 
-private slots:
+private Q_SLOTS:
     void validateNewPass();
     void validateNewPassRepeat();
     void onOldPassChanged();

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -130,7 +130,7 @@ OverviewPage::OverviewPage(QWidget* parent) : QDialog(parent, Qt::WindowSystemMe
 void OverviewPage::handleTransactionClicked(const QModelIndex& index)
 {
     if (filter)
-        emit transactionClicked(filter->mapToSource(index));
+        Q_EMIT transactionClicked(filter->mapToSource(index));
 }
 
 OverviewPage::~OverviewPage()

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -44,7 +44,7 @@ public:
     QTimer* animTicker;
     QElapsedTimer* animClock;
 
-public slots:
+public Q_SLOTS:
     void setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, 
                     const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance);
     void hideOrphans(bool fHide);
@@ -57,7 +57,7 @@ public slots:
     void showBlockCurrentHeight(int count);
     void updateBalance();
 
-signals:
+Q_SIGNALS:
     void transactionClicked(const QModelIndex& index);
 
 private:
@@ -90,7 +90,7 @@ private:
     void moveSyncCircle(QWidget* anchor, QWidget* animated, int deltaRadius, float degreesPerSecond, float angleOffset=0);
     QRect getCircleGeometry(QWidget* parent, float ratioToParent);
 
-private slots:
+private Q_SLOTS:
     void updateDisplayUnit();
     void handleTransactionClicked(const QModelIndex& index);
     void updateAlerts(const QString& warnings);

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -137,7 +137,7 @@ void PaymentServer::LoadRootCAs(X509_STORE* _store)
 
     int nRootCerts = 0;
     const QDateTime currentTime = QDateTime::currentDateTime();
-    foreach (const QSslCertificate& cert, certList) {
+   Q_FOREACH (const QSslCertificate& cert, certList) {
         if (currentTime < cert.effectiveDate() || currentTime > cert.expiryDate()) {
             ReportInvalidCertificate(cert);
             continue;
@@ -180,7 +180,7 @@ void PaymentServer::LoadRootCAs(X509_STORE* _store)
 // when uiReady() is called.
 //
 // Warning: ipcSendCommandLine() is called early in init,
-// so don't use "emit message()", but "QMessageBox::"!
+// so don't use "Q_EMIT message()", but "QMessageBox::"!
 //
 void PaymentServer::ipcParseCommandLine(int argc, char* argv[])
 {
@@ -236,7 +236,7 @@ void PaymentServer::ipcParseCommandLine(int argc, char* argv[])
 bool PaymentServer::ipcSendCommandLine()
 {
     bool fResult = false;
-    foreach (const QString& r, savedPaymentRequests) {
+   Q_FOREACH (const QString& r, savedPaymentRequests) {
         QLocalSocket* socket = new QLocalSocket();
         socket->connectToServer(ipcServerName(), QIODevice::WriteOnly);
         if (!socket->waitForConnected(BITCOIN_IPC_CONNECT_TIMEOUT)) {
@@ -289,7 +289,7 @@ PaymentServer::PaymentServer(QObject* parent, bool startLocalServer) : QObject(p
         uriServer = new QLocalServer(this);
 
         if (!uriServer->listen(name)) {
-            // constructor is called early in init, so don't use "emit message()" here
+            // constructor is called early in init, so don't use "Q_EMIT message()" here
             QMessageBox::critical(0, tr("Payment request error"),
                 tr("Cannot start dapscoin: click-to-pay handler"));
         } else {
@@ -355,7 +355,7 @@ void PaymentServer::uiReady()
     initNetManager();
 
     saveURIs = false;
-    foreach (const QString& s, savedPaymentRequests) {
+   Q_FOREACH (const QString& s, savedPaymentRequests) {
         handleURIOrFile(s);
     }
     savedPaymentRequests.clear();
@@ -375,12 +375,12 @@ void PaymentServer::handleURIOrFile(const QString& s)
         if (GUIUtil::parseBitcoinURI(s, &recipient)) {
             CBitcoinAddress address(recipient.address.toStdString());
             if (!address.IsValid()) {
-                emit message(tr("URI handling"), tr("Invalid payment address %1").arg(recipient.address),
+                Q_EMIT message(tr("URI handling"), tr("Invalid payment address %1").arg(recipient.address),
                     CClientUIInterface::MSG_ERROR);
             } else
-                emit receivedPaymentRequest(recipient);
+                Q_EMIT receivedPaymentRequest(recipient);
         } else
-            emit message(tr("URI handling"),
+            Q_EMIT message(tr("URI handling"),
                 tr("URI cannot be parsed! This can be caused by an invalid DAPS address or malformed URI parameters."),
                 CClientUIInterface::ICON_WARNING);
 
@@ -392,11 +392,11 @@ void PaymentServer::handleURIOrFile(const QString& s)
         PaymentRequestPlus request;
         SendCoinsRecipient recipient;
         if (!readPaymentRequestFromFile(s, request)) {
-            emit message(tr("Payment request file handling"),
+            Q_EMIT message(tr("Payment request file handling"),
                 tr("Payment request file cannot be read! This can be caused by an invalid payment request file."),
                 CClientUIInterface::ICON_WARNING);
         } else if (processPaymentRequest(request, recipient))
-            emit receivedPaymentRequest(recipient);
+            Q_EMIT receivedPaymentRequest(recipient);
 
         return;
     }
@@ -425,7 +425,7 @@ void PaymentServer::handleURIConnection()
 
 //
 // Warning: readPaymentRequestFromFile() is used in ipcSendCommandLine()
-// so don't use "emit message()", but "QMessageBox::"!
+// so don't use "Q_EMIT message()", but "QMessageBox::"!
 //
 bool PaymentServer::readPaymentRequestFromFile(const QString& filename, PaymentRequestPlus& request)
 {
@@ -460,7 +460,7 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoins
 
         // Payment request network matches client network?
         if (details.network() != Params().NetworkIDString()) {
-            emit message(tr("Payment request rejected"), tr("Payment request network doesn't match client network."),
+            Q_EMIT message(tr("Payment request rejected"), tr("Payment request network doesn't match client network."),
                 CClientUIInterface::MSG_ERROR);
 
             return false;
@@ -468,13 +468,13 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoins
 
         // Expired payment request?
         if (details.has_expires() && (int64_t)details.expires() < GetTime()) {
-            emit message(tr("Payment request rejected"), tr("Payment request has expired."),
+            Q_EMIT message(tr("Payment request rejected"), tr("Payment request has expired."),
                 CClientUIInterface::MSG_ERROR);
 
             return false;
         }
     } else {
-        emit message(tr("Payment request error"), tr("Payment request is not initialized."),
+        Q_EMIT message(tr("Payment request error"), tr("Payment request is not initialized."),
             CClientUIInterface::MSG_ERROR);
 
         return false;
@@ -488,7 +488,7 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoins
     QList<std::pair<CScript, CAmount> > sendingTos = request.getPayTo();
     QStringList addresses;
 
-    foreach (const PAIRTYPE(CScript, CAmount) & sendingTo, sendingTos) {
+   Q_FOREACH (const PAIRTYPE(CScript, CAmount) & sendingTo, sendingTos) {
         // Extract and check destination addresses
         CTxDestination dest;
         if (ExtractDestination(sendingTo.first, dest)) {
@@ -498,7 +498,7 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoins
             // Insecure payments to custom dapscoin addresses are not supported
             // (there is no good way to tell the user where they are paying in a way
             // they'd have a chance of understanding).
-            emit message(tr("Payment request rejected"),
+            Q_EMIT message(tr("Payment request rejected"),
                 tr("Unverified payment requests to custom payment scripts are unsupported."),
                 CClientUIInterface::MSG_ERROR);
             return false;
@@ -507,7 +507,7 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoins
         // Extract and check amounts
         CTxOut txOut(sendingTo.second, sendingTo.first);
         if (txOut.IsDust(::minRelayTxFee)) {
-            emit message(tr("Payment request error"), tr("Requested payment amount of %1 is too small (considered dust).").arg(BitcoinUnits::formatWithUnit(optionsModel->getDisplayUnit(), sendingTo.second)),
+            Q_EMIT message(tr("Payment request error"), tr("Requested payment amount of %1 is too small (considered dust).").arg(BitcoinUnits::formatWithUnit(optionsModel->getDisplayUnit(), sendingTo.second)),
                 CClientUIInterface::MSG_ERROR);
 
             return false;
@@ -601,7 +601,7 @@ void PaymentServer::netRequestFinished(QNetworkReply* reply)
                           .arg(BIP70_MAX_PAYMENTREQUEST_SIZE);
 
         qWarning() << QString("PaymentServer::%1:").arg(__func__) << msg;
-        emit message(tr("Payment request DoS protection"), msg, CClientUIInterface::MSG_ERROR);
+        Q_EMIT message(tr("Payment request DoS protection"), msg, CClientUIInterface::MSG_ERROR);
         return;
     }
 
@@ -611,7 +611,7 @@ void PaymentServer::netRequestFinished(QNetworkReply* reply)
                           .arg(reply->errorString());
 
         qWarning() << "PaymentServer::netRequestFinished: " << msg;
-        emit message(tr("Payment request error"), msg, CClientUIInterface::MSG_ERROR);
+        Q_EMIT message(tr("Payment request error"), msg, CClientUIInterface::MSG_ERROR);
         return;
     }
 
@@ -623,11 +623,11 @@ void PaymentServer::netRequestFinished(QNetworkReply* reply)
         SendCoinsRecipient recipient;
         if (!request.parse(data)) {
             qWarning() << "PaymentServer::netRequestFinished : Error parsing payment request";
-            emit message(tr("Payment request error"),
+            Q_EMIT message(tr("Payment request error"),
                 tr("Payment request cannot be parsed!"),
                 CClientUIInterface::MSG_ERROR);
         } else if (processPaymentRequest(request, recipient))
-            emit receivedPaymentRequest(recipient);
+            Q_EMIT receivedPaymentRequest(recipient);
 
         return;
     } else if (requestType == BIP70_MESSAGE_PAYMENTACK) {
@@ -637,9 +637,9 @@ void PaymentServer::netRequestFinished(QNetworkReply* reply)
                               .arg(reply->request().url().toString());
 
             qWarning() << "PaymentServer::netRequestFinished : " << msg;
-            emit message(tr("Payment request error"), msg, CClientUIInterface::MSG_ERROR);
+            Q_EMIT message(tr("Payment request error"), msg, CClientUIInterface::MSG_ERROR);
         } else {
-            emit receivedPaymentACK(GUIUtil::HtmlEscape(paymentACK.memo()));
+            Q_EMIT receivedPaymentACK(GUIUtil::HtmlEscape(paymentACK.memo()));
         }
     }
 }
@@ -649,11 +649,11 @@ void PaymentServer::reportSslErrors(QNetworkReply* reply, const QList<QSslError>
     Q_UNUSED(reply);
 
     QString errString;
-    foreach (const QSslError& err, errs) {
+   Q_FOREACH (const QSslError& err, errs) {
         qWarning() << "PaymentServer::reportSslErrors : " << err;
         errString += err.errorString() + "\n";
     }
-    emit message(tr("Network request error"), errString, CClientUIInterface::MSG_ERROR);
+    Q_EMIT message(tr("Network request error"), errString, CClientUIInterface::MSG_ERROR);
 }
 
 void PaymentServer::setOptionsModel(OptionsModel* optionsModel)
@@ -664,7 +664,7 @@ void PaymentServer::setOptionsModel(OptionsModel* optionsModel)
 void PaymentServer::handlePaymentACK(const QString& paymentACKMsg)
 {
     // currently we don't futher process or store the paymentACK message
-    emit message(tr("Payment acknowledged"), paymentACKMsg, CClientUIInterface::ICON_INFORMATION | CClientUIInterface::MODAL);
+    Q_EMIT message(tr("Payment acknowledged"), paymentACKMsg, CClientUIInterface::ICON_INFORMATION | CClientUIInterface::MODAL);
 }
 
 X509_STORE* PaymentServer::getCertStore()

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -91,7 +91,7 @@ public:
     // This is now public, because we use it in paymentservertests.cpp
     static bool readPaymentRequestFromFile(const QString& filename, PaymentRequestPlus& request);
 
-signals:
+Q_SIGNALS:
     // Fired when a valid payment request is received
     void receivedPaymentRequest(SendCoinsRecipient);
 
@@ -101,7 +101,7 @@ signals:
     // Fired when a message should be reported to the user
     void message(const QString& title, const QString& message, unsigned int style);
 
-public slots:
+public Q_SLOTS:
     // Signal this when the main window's UI is ready
     // to display payment requests to the user
     void uiReady();
@@ -112,7 +112,7 @@ public slots:
     // Handle an incoming URI, URI with local file scheme or file
     void handleURIOrFile(const QString& s);
 
-private slots:
+private Q_SLOTS:
     void handleURIConnection();
     void netRequestFinished(QNetworkReply*);
     void reportSslErrors(QNetworkReply*, const QList<QSslError>&);

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -214,9 +214,9 @@ const CNodeCombinedStats* PeerTableModel::getNodeStats(int idx)
 
 void PeerTableModel::refresh()
 {
-    emit layoutAboutToBeChanged();
+    Q_EMIT layoutAboutToBeChanged();
     priv->refreshPeers();
-    emit layoutChanged();
+    Q_EMIT layoutChanged();
 }
 
 int PeerTableModel::getRowByNodeId(NodeId nodeid)

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -68,7 +68,7 @@ public:
     void sort(int column, Qt::SortOrder order);
     /*@}*/
 
-public slots:
+public Q_SLOTS:
     void refresh();
 
 private:

--- a/src/qt/qvalidatedlineedit.h
+++ b/src/qt/qvalidatedlineedit.h
@@ -27,11 +27,11 @@ private:
     bool valid;
     const QValidator* checkValidator;
 
-public slots:
+public Q_SLOTS:
     void setValid(bool valid);
     void setEnabled(bool enabled);
 
-private slots:
+private Q_SLOTS:
     void markValid();
     void checkValidity();
 };

--- a/src/qt/qvaluecombobox.cpp
+++ b/src/qt/qvaluecombobox.cpp
@@ -26,5 +26,5 @@ void QValueComboBox::setRole(int role)
 
 void QValueComboBox::handleSelectionChanged(int idx)
 {
-    emit valueChanged();
+    Q_EMIT valueChanged();
 }

--- a/src/qt/qvaluecombobox.h
+++ b/src/qt/qvaluecombobox.h
@@ -24,13 +24,13 @@ public:
     /** Specify model role to use as ordinal value (defaults to Qt::UserRole) */
     void setRole(int role);
 
-signals:
+Q_SIGNALS:
     void valueChanged();
 
 private:
     int role;
 
-private slots:
+private Q_SLOTS:
     void handleSelectionChanged(int idx);
 };
 

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -48,7 +48,7 @@ public:
     void setModel(WalletModel* model);
     void loadAccount();
 
-public slots:
+public Q_SLOTS:
     void clear();
     void reject();
     void accept();
@@ -66,7 +66,7 @@ private:
     virtual void resizeEvent(QResizeEvent* event);
     CAmount getValidatedAmount();
 
-private slots:
+private Q_SLOTS:
     void on_receiveButton_clicked();
     void updateDisplayUnit();
 

--- a/src/qt/receiverequestdialog.h
+++ b/src/qt/receiverequestdialog.h
@@ -33,7 +33,7 @@ public:
     explicit QRImageWidget(QWidget* parent = 0);
     QImage exportImage();
 
-public slots:
+public Q_SLOTS:
     void saveImage();
     void copyImage();
 
@@ -56,7 +56,7 @@ public:
     void setModel(OptionsModel* model);
     void setInfo(const SendCoinsRecipient& info);
 
-private slots:
+private Q_SLOTS:
     void on_btnCopyURI_clicked();
     void on_btnCopyAddress_clicked();
 

--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -107,7 +107,7 @@ QVariant RecentRequestsTableModel::headerData(int section, Qt::Orientation orien
 void RecentRequestsTableModel::updateAmountColumnTitle()
 {
     columns[Amount] = getAmountTitle();
-    emit headerDataChanged(Qt::Horizontal, Amount, Amount);
+    Q_EMIT headerDataChanged(Qt::Horizontal, Amount, Amount);
 }
 
 /** Gets title for amount column including current display unit if optionsModel reference available. */
@@ -199,7 +199,7 @@ void RecentRequestsTableModel::addNewRequest(RecentRequestEntry& recipient)
 void RecentRequestsTableModel::sort(int column, Qt::SortOrder order)
 {
     std::sort(list.begin(), list.end(), RecentRequestEntryLessThan(column, order));
-    emit dataChanged(index(0, 0, QModelIndex()), index(list.size() - 1, NUMBER_OF_COLUMNS - 1, QModelIndex()));
+    Q_EMIT dataChanged(index(0, 0, QModelIndex()), index(list.size() - 1, NUMBER_OF_COLUMNS - 1, QModelIndex()));
 }
 
 void RecentRequestsTableModel::updateDisplayUnit()

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -90,7 +90,7 @@ public:
     void addNewRequest(const std::string& recipient);
     void addNewRequest(RecentRequestEntry& recipient);
 
-public slots:
+public Q_SLOTS:
     void sort(int column, Qt::SortOrder order = Qt::AscendingOrder);
     void updateDisplayUnit();
 

--- a/src/qt/revealtxdialog.h
+++ b/src/qt/revealtxdialog.h
@@ -21,7 +21,7 @@ public:
     void setTxPrivKey(QString strPrivKey);
     void setTxFee(CAmount fee);
 
-private slots:
+private Q_SLOTS:
     void on_buttonBox_accepted();
     void copyID();
     void copyAddress();

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -70,10 +70,10 @@ class RPCExecutor : public QObject
 {
     Q_OBJECT
 
-public slots:
+public Q_SLOTS:
     void request(const QString& command);
 
-signals:
+Q_SIGNALS:
     void reply(int category, const QString& command);
 };
 
@@ -93,7 +93,7 @@ public:
         timer.start(millis);
     }
     ~QtRPCTimerBase() {}
-private slots:
+private Q_SLOTS:
             void timeout() { func(); }
 private:
     QTimer timer;
@@ -138,7 +138,7 @@ bool parseCommandLine(std::vector<std::string>& args, const std::string& strComm
         STATE_ESCAPE_DOUBLEQUOTED
     } state = STATE_EATING_SPACES;
     std::string curarg;
-    foreach (char ch, strCommand) {
+   Q_FOREACH (char ch, strCommand) {
         switch (state) {
         case STATE_ARGUMENT:      // In or after argument
         case STATE_EATING_SPACES: // Handle runs of whitespace
@@ -215,7 +215,7 @@ void RPCExecutor::request(const QString& command)
 {
     std::vector<std::string> args;
     if (!parseCommandLine(args, command.toStdString())) {
-        emit reply(RPCConsole::CMD_ERROR, QString("Parse error: unbalanced ' or \""));
+        Q_EMIT reply(RPCConsole::CMD_ERROR, QString("Parse error: unbalanced ' or \""));
         return;
     }
     if (args.empty())
@@ -236,19 +236,19 @@ void RPCExecutor::request(const QString& command)
         else
             strPrint = result.write(2);
 
-        emit reply(RPCConsole::CMD_REPLY, QString::fromStdString(strPrint));
+        Q_EMIT reply(RPCConsole::CMD_REPLY, QString::fromStdString(strPrint));
     } catch (UniValue& objError) {
         try // Nice formatting for standard-format error
         {
             int code = find_value(objError, "code").get_int();
             std::string message = find_value(objError, "message").get_str();
-            emit reply(RPCConsole::CMD_ERROR, QString::fromStdString(message) + " (code " + QString::number(code) + ")");
+            Q_EMIT reply(RPCConsole::CMD_ERROR, QString::fromStdString(message) + " (code " + QString::number(code) + ")");
         } catch (std::runtime_error&) // raised when converting to invalid type, i.e. missing code or message
         {                             // Show raw JSON object
-            emit reply(RPCConsole::CMD_ERROR, QString::fromStdString(objError.write()));
+            Q_EMIT reply(RPCConsole::CMD_ERROR, QString::fromStdString(objError.write()));
         }
     } catch (std::exception& e) {
-        emit reply(RPCConsole::CMD_ERROR, QString("Error: ") + QString::fromStdString(e.what()));
+        Q_EMIT reply(RPCConsole::CMD_ERROR, QString("Error: ") + QString::fromStdString(e.what()));
     }
 }
 
@@ -309,7 +309,7 @@ RPCConsole::RPCConsole(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenuHi
 RPCConsole::~RPCConsole()
 {
     GUIUtil::saveWindowGeometry("nRPCConsoleWindow", this);
-    emit stopExecutor();
+    Q_EMIT stopExecutor();
     delete peersTableContextMenu;
     delete banTableContextMenu;
     RPCUnsetTimerInterface(rpcTimerInterface);
@@ -354,7 +354,7 @@ bool RPCConsole::eventFilter(QObject* obj, QEvent* event)
             break;
         default:
             // Typing in messages widget brings focus to line edit, and redirects key there
-            // Exclude most combinations and keys that emit no text, except paste shortcuts
+            // Exclude most combinations and keys that Q_EMIT no text, except paste shortcuts
             if (obj == ui->messagesWidget && ((!mod && !keyevt->text().isEmpty() && key != Qt::Key_Tab) ||
                                                  ((mod & Qt::ControlModifier) && key == Qt::Key_V) ||
                                                  ((mod & Qt::ShiftModifier) && key == Qt::Key_Insert))) {
@@ -583,7 +583,7 @@ void RPCConsole::buildParameterlist(QString arg)
     args.append(arg);
 
     // Send command-line arguments to BitcoinGUI::handleRestart()
-    emit handleRestart(args);
+    Q_EMIT handleRestart(args);
 }
 
 void RPCConsole::clear()
@@ -684,7 +684,7 @@ void RPCConsole::on_lineEdit_returnPressed()
 
     if (!cmd.isEmpty()) {
         message(CMD_REQUEST, cmd);
-        emit cmdRequest(cmd);
+        Q_EMIT cmdRequest(cmd);
         // Remove command, if already in history
         history.removeOne(cmd);
         // Append command to history

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -48,7 +48,7 @@ public:
 protected:
     virtual bool eventFilter(QObject* obj, QEvent* event);
 
-private slots:
+private Q_SLOTS:
     void on_lineEdit_returnPressed();
     void on_tabWidget_currentChanged(int index);
     /** open the debug.log from the current datadir */
@@ -69,7 +69,7 @@ private slots:
     /** clear the selected node */
     void clearSelectedNode();
 
-public slots:
+public Q_SLOTS:
     void clear();
 
     /** Wallet repair options */
@@ -122,7 +122,7 @@ public slots:
     /** Show folder with wallet backups in default browser */
     void showBackups();
 
-signals:
+Q_SIGNALS:
     // For RPC command executor
     void stopExecutor();
     void cmdRequest(const QString& command);

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -40,7 +40,7 @@ public:
     void setModel(WalletModel* model);
     bool fSplitBlock;
 
-public slots:
+public Q_SLOTS:
     SendCoinsEntry* addEntry();
 
 private:
@@ -55,7 +55,7 @@ private:
 private:
     void sendTx();
     
-private slots:
+private Q_SLOTS:
     void dialogIsFinished(int result);
     void on_sendButton_clicked();
     void setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, 
@@ -74,7 +74,7 @@ private slots:
     void coinControlClipboardLowOutput();
     void coinControlClipboardChange();
 
-signals:
+Q_SIGNALS:
 
 };
 

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -120,7 +120,7 @@ void SendCoinsEntry::clear()
 
 void SendCoinsEntry::deleteClicked()
 {
-    emit removeEntry(this);
+    Q_EMIT removeEntry(this);
 }
 
 static inline int64_t roundint64(double d)

--- a/src/qt/sendcoinsentry.h
+++ b/src/qt/sendcoinsentry.h
@@ -48,15 +48,15 @@ public:
 
     void setFocus();
 
-public slots:
+public Q_SLOTS:
     void clear();
 
-signals:
+Q_SIGNALS:
     void removeEntry(SendCoinsEntry* entry);
     void payAmountChanged();
     void validateAmount(const QString& textAmount);
 
-private slots:
+private Q_SLOTS:
     void deleteClicked();
     void on_payTo_textChanged(const QString& address);
     void on_addressBookButton_clicked();

--- a/src/qt/signverifymessagedialog.h
+++ b/src/qt/signverifymessagedialog.h
@@ -36,7 +36,7 @@ private:
     Ui::SignVerifyMessageDialog* ui;
     WalletModel* model;
 
-private slots:
+private Q_SLOTS:
     /* sign message */
     void on_addressBookButton_SM_clicked();
     void on_pasteButton_SM_clicked();

--- a/src/qt/splashscreen.h
+++ b/src/qt/splashscreen.h
@@ -27,7 +27,7 @@ protected:
     void paintEvent(QPaintEvent* event);
     void closeEvent(QCloseEvent* event);
 
-public slots:
+public Q_SLOTS:
     /** Slot to call finish() method as it's not defined as slot */
     void slotFinish(QWidget* mainWin);
 

--- a/src/qt/test/paymentservertests.h
+++ b/src/qt/test/paymentservertests.h
@@ -14,7 +14,7 @@ class PaymentServerTests : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void paymentServerTests();
 };
 
@@ -25,7 +25,7 @@ class RecipientCatcher : public QObject
 {
     Q_OBJECT
 
-public slots:
+public Q_SLOTS:
     void getRecipient(SendCoinsRecipient r);
 
 public:

--- a/src/qt/test/uritests.h
+++ b/src/qt/test/uritests.h
@@ -12,7 +12,7 @@ class URITests : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void uriTests();
 };
 

--- a/src/qt/togglebutton.cpp
+++ b/src/qt/togglebutton.cpp
@@ -93,7 +93,7 @@ void ToggleButton::setState(bool value)
 void ToggleButton::toggle()
 {
     state=!state;
-    emit stateChanged(this);
+    Q_EMIT stateChanged(this);
     update();
 }
 

--- a/src/qt/togglebutton.h
+++ b/src/qt/togglebutton.h
@@ -30,12 +30,12 @@ protected:
     void resizeEvent(QResizeEvent * event);
     void paintEvent(QPaintEvent *);
 
-public slots:
+public Q_SLOTS:
     void toggle();
 
-signals:
+Q_SIGNALS:
     void stateChanged(ToggleButton* widget);
-private slots:
+private Q_SLOTS:
 
 private:
     Ui::ToggleButton* ui;

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -138,10 +138,10 @@ void TrafficGraphWidget::updateRates()
     }
 
     float tmax = 0.0f;
-    foreach (float f, vSamplesIn) {
+   Q_FOREACH (float f, vSamplesIn) {
         if (f > tmax) tmax = f;
     }
-    foreach (float f, vSamplesOut) {
+   Q_FOREACH (float f, vSamplesOut) {
         if (f > tmax) tmax = f;
     }
     fMax = tmax;

--- a/src/qt/trafficgraphwidget.h
+++ b/src/qt/trafficgraphwidget.h
@@ -27,7 +27,7 @@ public:
 protected:
     void paintEvent(QPaintEvent*);
 
-public slots:
+public Q_SLOTS:
     void updateRates();
     void setGraphRangeMins(int mins);
     void clear();

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -258,14 +258,14 @@ QString TransactionDesc::toHTML(CWallet* wallet, CWalletTx& wtx, TransactionReco
     strHTML += "<b>" + tr("Output index") + ":</b> " + QString::number(rec->getOutputIndex()) + "<br>";
 
     // Message from normal dapscoin:URI (dapscoin:XyZ...?message=example)
-    foreach (const PAIRTYPE(string, string) & r, wtx.vOrderForm)
+   Q_FOREACH (const PAIRTYPE(string, string) & r, wtx.vOrderForm)
         if (r.first == "Message")
             strHTML += "<br><b>" + tr("Message") + ":</b><br>" + GUIUtil::HtmlEscape(r.second, true) + "<br>";
 
     //
     // PaymentRequest info:
     //
-    foreach (const PAIRTYPE(string, string) & r, wtx.vOrderForm) {
+   Q_FOREACH (const PAIRTYPE(string, string) & r, wtx.vOrderForm) {
         if (r.first == "PaymentRequest") {
             PaymentRequestPlus req;
             req.parse(QByteArray::fromRawData(r.second.data(), r.second.size()));

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -210,7 +210,7 @@ public:
                 {
                     parent->beginInsertRows(QModelIndex(), lowerIndex, lowerIndex + toInsert.size() - 1);
                     int insert_idx = lowerIndex;
-                    foreach (const TransactionRecord& rec, toInsert) {
+                   Q_FOREACH (const TransactionRecord& rec, toInsert) {
                         cachedWallet.insert(insert_idx, rec);
                         insert_idx += 1;
                     }
@@ -305,7 +305,7 @@ TransactionTableModel::~TransactionTableModel()
 void TransactionTableModel::updateAmountColumnTitle()
 {
     columns[Amount] = BitcoinUnits::getAmountColumnTitle(walletModel->getOptionsModel()->getDisplayUnit());
-    emit headerDataChanged(Qt::Horizontal, Amount, Amount);
+    Q_EMIT headerDataChanged(Qt::Horizontal, Amount, Amount);
 }
 
 void TransactionTableModel::updateTransaction(const QString& hash, int status, bool showTransaction)
@@ -314,7 +314,7 @@ void TransactionTableModel::updateTransaction(const QString& hash, int status, b
     updated.SetHex(hash.toStdString());
 
     priv->updateWallet(updated, status, showTransaction);
-    emit walletModel->RefreshRecent();
+    Q_EMIT walletModel->RefreshRecent();
 }
 
 void TransactionTableModel::updateConfirmations()
@@ -323,8 +323,8 @@ void TransactionTableModel::updateConfirmations()
     // Invalidate status (number of confirmations) and (possibly) description
     //  for all rows. Qt is smart enough to only actually request the data for the
     //  visible rows.
-    emit dataChanged(index(0, Status), index(priv->size() - 1, Status));
-    emit dataChanged(index(0, ToAddress), index(priv->size() - 1, ToAddress));
+    Q_EMIT dataChanged(index(0, Status), index(priv->size() - 1, Status));
+    Q_EMIT dataChanged(index(0, ToAddress), index(priv->size() - 1, ToAddress));
 }
 
 int TransactionTableModel::rowCount(const QModelIndex& parent) const
@@ -717,9 +717,9 @@ QModelIndex TransactionTableModel::index(int row, int column, const QModelIndex&
 
 void TransactionTableModel::updateDisplayUnit()
 {
-    // emit dataChanged to update Amount column with the current unit
+    // Q_EMIT dataChanged to update Amount column with the current unit
     updateAmountColumnTitle();
-    emit dataChanged(index(0, Amount), index(priv->size() - 1, Amount));
+    Q_EMIT dataChanged(index(0, Amount), index(priv->size() - 1, Amount));
 }
 
 // queue notifications to show a non freezing progress dialog e.g. for rescan

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -98,7 +98,7 @@ private:
     QVariant txWatchonlyDecoration(const TransactionRecord* wtx) const;
     QVariant txAddressDecoration(const TransactionRecord* wtx) const;
 
-public slots:
+public Q_SLOTS:
     /* New transaction, or transaction changed status */
     void updateTransaction(const QString& hash, int status, bool showTransaction);
     void updateConfirmations();

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -326,7 +326,7 @@ void TransactionView::updateHideOrphans(bool fHide)
     if (settings.value("fHideOrphans", false).toBool() != fHide) {
         settings.setValue("fHideOrphans", fHide);
         if (model && model->getOptionsModel())
-            emit model->getOptionsModel()->hideOrphansChanged(fHide);
+            Q_EMIT model->getOptionsModel()->hideOrphansChanged(fHide);
     }
     hideOrphans(fHide);
     // retain consistency with other checkboxes
@@ -399,11 +399,11 @@ void TransactionView::exportClicked()
     }
 
     if (fExport) {
-        emit message(tr("Exporting Successful"), tr("The transaction history was successfully saved to %1.").arg(filename),
+        Q_EMIT message(tr("Exporting Successful"), tr("The transaction history was successfully saved to %1.").arg(filename),
                      CClientUIInterface::MSG_INFORMATION);
     } 
     else {
-        emit message(tr("Exporting Failed"), tr("There was an error trying to save the transaction history to %1.").arg(filename),
+        Q_EMIT message(tr("Exporting Failed"), tr("There was an error trying to save the transaction history to %1.").arg(filename),
                      CClientUIInterface::MSG_ERROR);
     }
 }
@@ -495,12 +495,12 @@ void TransactionView::computeSum()
         return;
     QModelIndexList selection = transactionView->selectionModel()->selectedRows();
 
-    foreach (QModelIndex index, selection) {
+   Q_FOREACH (QModelIndex index, selection) {
         amount += index.data(TransactionTableModel::AmountRole).toLongLong();
     }
     QString strAmount(BitcoinUnits::formatWithUnit(nDisplayUnit, amount, true, BitcoinUnits::separatorAlways));
     if (amount < 0) strAmount = "<span style='color:red;'>" + strAmount + "</span>";
-    emit trxAmount(strAmount);
+    Q_EMIT trxAmount(strAmount);
 }
 
 void TransactionView::openThirdPartyTxUrl(QString url)

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -85,7 +85,7 @@ private:
 
     bool eventFilter(QObject* obj, QEvent* event);
 
-private slots:
+private Q_SLOTS:
     void contextualMenu(const QPoint&);
     void dateRangeChanged();
     void showDetails();
@@ -97,7 +97,7 @@ private slots:
     void openThirdPartyTxUrl(QString url);
     void updateWatchOnlyColumn(bool fHaveWatchOnly);
 
-signals:
+Q_SIGNALS:
     void doubleClicked(const QModelIndex&);
 
     /**  Fired when a message should be reported to the user */
@@ -106,7 +106,7 @@ signals:
     /** Send computed sum back to wallet-view */
     void trxAmount(QString amount);
 
-public slots:
+public Q_SLOTS:
     void chooseDate(int idx);
     void chooseType(int idx);
     void hideOrphans(bool fHide);

--- a/src/qt/txentry.h
+++ b/src/qt/txentry.h
@@ -30,11 +30,11 @@ public:
 protected:
     void resizeEvent(QResizeEvent *event);
 
-public slots:
+public Q_SLOTS:
 
-signals:
+Q_SIGNALS:
 
-private slots:
+private Q_SLOTS:
 void on_pushButtonExpand_clicked();
 
 private:

--- a/src/qt/utilitydialog.h
+++ b/src/qt/utilitydialog.h
@@ -32,7 +32,7 @@ private:
     Ui::HelpMessageDialog* ui;
     QString text;
 
-private slots:
+private Q_SLOTS:
     void on_okButton_accepted();
 };
 

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -44,7 +44,7 @@ private:
     bool bOutOfSync;
     WalletView* currentWalletView();
 
-public slots:
+public Q_SLOTS:
     /** Switch to overview (home) page */
     void gotoOverviewPage();
     /** Switch to history (transactions) page */

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -126,7 +126,7 @@ void WalletModel::updateStatus()
     EncryptionStatus newEncryptionStatus = getEncryptionStatus();
 
     if (cachedEncryptionStatus != newEncryptionStatus)
-        emit encryptionStatusChanged(newEncryptionStatus);
+        Q_EMIT encryptionStatusChanged(newEncryptionStatus);
 }
 
 bool IsImportingOrReindexing() {
@@ -136,7 +136,7 @@ bool IsImportingOrReindexing() {
 void WalletModel::pollBalanceChanged()
 {
 	if (wallet->walletUnlockCountStatus == 1) {
-		emit WalletUnlocked();
+		Q_EMIT WalletUnlocked();
 		wallet->walletUnlockCountStatus++;
 	}
 
@@ -181,7 +181,7 @@ void WalletModel::emitBalanceChanged()
     if (cachedBalance == 0 && !checkBalanceChanged())
         return;
     
-    emit balanceChanged(cachedBalance, cachedUnconfirmedBalance, cachedImmatureBalance,
+    Q_EMIT balanceChanged(cachedBalance, cachedUnconfirmedBalance, cachedImmatureBalance,
         cachedWatchOnlyBalance, cachedWatchUnconfBalance, cachedWatchImmatureBalance);
 }
 
@@ -226,7 +226,7 @@ bool WalletModel::checkBalanceChanged()
         cachedWatchImmatureBalance = newWatchImmatureBalance;
         stkEnabled = (nLastCoinStakeSearchInterval > 0);
         walletLocked = pwalletMain->IsLocked();
-        emit balanceChanged(newBalance, newUnconfirmedBalance, newImmatureBalance,
+        Q_EMIT balanceChanged(newBalance, newUnconfirmedBalance, newImmatureBalance,
             newWatchOnlyBalance, newWatchUnconfBalance, newWatchImmatureBalance);
         return true;
     }
@@ -255,13 +255,13 @@ void WalletModel::updateAddressBook(const QString& pubCoin, const QString& isUse
 void WalletModel::updateWatchOnlyFlag(bool fHaveWatchonly)
 {
     fHaveWatchOnly = fHaveWatchonly;
-    emit notifyWatchonlyChanged(fHaveWatchonly);
+    Q_EMIT notifyWatchonlyChanged(fHaveWatchonly);
 }
 
 void WalletModel::updateMultiSigFlag(bool fHaveMultiSig)
 {
     this->fHaveMultiSig = fHaveMultiSig;
-    emit notifyMultiSigChanged(fHaveMultiSig);
+    Q_EMIT notifyMultiSigChanged(fHaveMultiSig);
 }
 
 bool WalletModel::validateAddress(const QString& address)
@@ -289,7 +289,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
     int nAddresses = 0;
 
     // Pre-check input data for validity
-    foreach (const SendCoinsRecipient& rcp, recipients) {
+   Q_FOREACH (const SendCoinsRecipient& rcp, recipients) {
         if (rcp.paymentRequest.IsInitialized()) { // PaymentRequest...
             CAmount subtotal = 0;
             const payments::PaymentDetails& details = rcp.paymentRequest.getDetails();
@@ -348,7 +348,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
             if ((total + nFeeRequired) > nBalance) {
                 return SendCoinsReturn(AmountWithFeeExceedsBalance);
             }
-            emit message(tr("Send Coins"), QString::fromStdString(strFailReason),
+            Q_EMIT message(tr("Send Coins"), QString::fromStdString(strFailReason),
                 CClientUIInterface::MSG_ERROR);
             return TransactionCreationFailed;
         }
@@ -557,7 +557,7 @@ WalletModel::UnlockContext WalletModel::requestUnlock(AskPassphraseDialog::Conte
 
     if (was_locked) {
         // Request UI to unlock wallet
-        emit requireUnlock(context);
+        Q_EMIT requireUnlock(context);
     }
     // If wallet is still locked, unlock was failed or cancelled, mark context as invalid
     bool valid = getEncryptionStatus() != Locked;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -258,7 +258,7 @@ private:
     void unsubscribeFromCoreSignals();
     bool checkBalanceChanged();
 
-signals:
+Q_SIGNALS:
     // Signal that balance in wallet changed
     void balanceChanged(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance);
     void stakingStatusChanged(bool isStaking);
@@ -288,7 +288,7 @@ signals:
     void RefreshRecent();
     void WalletUnlocked();
 
-public slots:
+public Q_SLOTS:
     /* Wallet status might have changed */
     void updateStatus();
     /* New transaction, or transaction changed status */
@@ -300,7 +300,7 @@ public slots:
     void updateWatchOnlyFlag(bool fHaveWatchonly);
     /* MultiSig added */
     void updateMultiSigFlag(bool fHaveMultiSig);
-    /* Current, immature or unconfirmed balance might have changed - emit 'balanceChanged' if so */
+    /* Current, immature or unconfirmed balance might have changed - Q_EMIT 'balanceChanged' if so */
     void pollBalanceChanged();
 };
 

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -48,7 +48,7 @@ void WalletModelTransaction::setTransactionFee(const CAmount& newFee)
 CAmount WalletModelTransaction::getTotalTransactionAmount()
 {
     CAmount totalTransactionAmount = 0;
-    foreach (const SendCoinsRecipient& rcp, recipients) {
+   Q_FOREACH (const SendCoinsRecipient& rcp, recipients) {
         totalTransactionAmount += rcp.amount;
     }
     return totalTransactionAmount;

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -120,7 +120,7 @@ void WalletView::setBitcoinGUI(BitcoinGUI* gui)
 
 void WalletView::stakingStatus(bool stt)
 {
-	emit stakingStatusChanged(stt);
+	Q_EMIT stakingStatusChanged(stt);
 }
 
 void WalletView::setClientModel(ClientModel* clientModel)
@@ -182,7 +182,7 @@ void WalletView::processNewTransaction(const QModelIndex& parent, int start, int
     QString address = ttm->index(start, TransactionTableModel::ToAddress, parent).data().toString();
     QString confirmations = ttm->index(start, TransactionTableModel::Confirmations, parent).data().toString();
 
-    emit incomingTransaction(date, walletModel->getOptionsModel()->getDisplayUnit(), amount, type, address, confirmations);
+    Q_EMIT incomingTransaction(date, walletModel->getOptionsModel()->getDisplayUnit(), amount, type, address, confirmations);
 }
 
 void WalletView::gotoOverviewPage()
@@ -248,7 +248,7 @@ void WalletView::showSyncStatus(bool fShow)
 
 void WalletView::updateEncryptionStatus()
 {
-    emit encryptionStatusChanged(walletModel->getEncryptionStatus());
+    Q_EMIT encryptionStatusChanged(walletModel->getEncryptionStatus());
 }
 
 void WalletView::encryptWallet(bool status)
@@ -272,10 +272,10 @@ void WalletView::backupWallet()
         return;
 
     if (!walletModel->backupWallet(filename)) {
-        emit message(tr("Backup Failed"), tr("There was an error trying to save the wallet data to %1.").arg(filename),
+        Q_EMIT message(tr("Backup Failed"), tr("There was an error trying to save the wallet data to %1.").arg(filename),
             CClientUIInterface::MSG_ERROR);
     } else {
-        emit message(tr("Backup Successful"), tr("The wallet data was successfully saved to %1.").arg(filename),
+        Q_EMIT message(tr("Backup Successful"), tr("The wallet data was successfully saved to %1.").arg(filename),
             CClientUIInterface::MSG_INFORMATION);
     }
 }

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -75,7 +75,7 @@ private:
     QProgressDialog* progressDialog;
     QLabel* transactionSum;
 
-public slots:
+public Q_SLOTS:
     /** Switch to overview (home) page */
     void gotoOverviewPage();
     /** Switch to history (transactions) page */
@@ -118,7 +118,7 @@ public slots:
     /** Show used receiving addresses */
     void usedReceivingAddresses();
 
-    /** Re-emit encryption status signal */
+    /** Re-Q_EMIT encryption status signal */
     void updateEncryptionStatus();
 
     /** Show progress dialog e.g. for rescan */
@@ -128,7 +128,7 @@ public slots:
     void trxAmount(QString amount);
     void stakingStatus(bool);
 
-signals:
+Q_SIGNALS:
     /** Signal that we want to show the main window */
     void showNormalIfMinimized();
     /**  Fired when a message should be reported to the user */


### PR DESCRIPTION
> QT_NO_KEYWORDS prevents Qt from defining the `foreach`, `signals`, `slots` and `emit` macros.
> 
> This avoids overlap between Qt macros and boost, and enforces the standard.
> 
> Ported mostly from [bitcoin#6433](https://github.com/bitcoin/bitcoin/pull/6433)

from https://github.com/PIVX-Project/PIVX/pull/1044