### PR TITLE
[Trivial] Replace qWarning() with qDebug() for cleaner debug.log (Windows only)

### DIFF
--- a/src/qt/winshutdownmonitor.cpp
+++ b/src/qt/winshutdownmonitor.cpp
@@ -55,13 +55,13 @@ void WinShutdownMonitor::registerShutdownBlockReason(const QString& strReason, c
     typedef BOOL(WINAPI * PSHUTDOWNBRCREATE)(HWND, LPCWSTR);
     PSHUTDOWNBRCREATE shutdownBRCreate = (PSHUTDOWNBRCREATE)GetProcAddress(GetModuleHandleA("User32.dll"), "ShutdownBlockReasonCreate");
     if (shutdownBRCreate == NULL) {
-        qWarning() << "registerShutdownBlockReason: GetProcAddress for ShutdownBlockReasonCreate failed";
+        qDebug() << "registerShutdownBlockReason: GetProcAddress for ShutdownBlockReasonCreate failed";
         return;
     }
 
     if (shutdownBRCreate(mainWinId, strReason.toStdWString().c_str()))
-        qWarning() << "registerShutdownBlockReason: Successfully registered: " + strReason;
+        qDebug() << "registerShutdownBlockReason: Successfully registered: " + strReason;
     else
-        qWarning() << "registerShutdownBlockReason: Failed to register: " + strReason;
+        qDebug() << "registerShutdownBlockReason: Failed to register: " + strReason;
 }
 #endif


### PR DESCRIPTION
Removes the "GUI: $registerShutdownBlockReason: Successfully registered: DAPS didn$t yet exit safely...$" line from debug.log and outputs it to qDebug instead