### PR TITLE
[Upstream][GUI] Less GUI locks, IBD state cached..

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -167,7 +167,7 @@ void ClientModel::updateAlert()
 
 bool ClientModel::inInitialBlockDownload() const
 {
-    return IsInitialBlockDownload();
+    return cachedInitialSync;
 }
 
 enum BlockSource ClientModel::getBlockSource() const
@@ -252,6 +252,7 @@ static void BlockTipChanged(ClientModel *clientmodel, bool initialSync, const CB
         clientmodel->setCacheTip(pIndex);
         clientmodel->setCacheImporting(fImporting);
         clientmodel->setCacheReindexing(fReindex);
+        clientmodel->setCacheInitialSync(initialSync);
         Q_EMIT clientmodel->numBlocksChanged(pIndex->nHeight);
         nLastBlockTipUpdateNotification = now;
     }

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -84,9 +84,10 @@ public:
 
     bool getTorInfo(std::string& ip_port) const;
 
-    void setCacheTip(const CBlockIndex* const tip) { cacheTip = tip; };
-    void setCacheReindexing(bool reindex) { cachedReindexing = reindex; };
-    void setCacheImporting(bool import) { cachedImporting = import; };
+    void setCacheTip(const CBlockIndex* const tip) { cacheTip = tip; }
+    void setCacheReindexing(bool reindex) { cachedReindexing = reindex; }
+    void setCacheImporting(bool import) { cachedImporting = import; }
+    void setCacheInitialSync(bool _initialSync) { cachedInitialSync = _initialSync; }
 
 private:
     OptionsModel* optionsModel;
@@ -97,6 +98,7 @@ private:
     QString cachedMasternodeCountString;
     bool cachedReindexing;
     bool cachedImporting;
+    bool cachedInitialSync;
 
     int numBlocksAtStartup;
 


### PR DESCRIPTION
> We were locking `cs_main`, calling `IsInitialBlockDownload` on every new row inserted in the transaction table model.
> 
> This PR caches the IBD state and updates it on every new block from the back-end without lock `cs_main` at all.

from https://github.com/PIVX-Project/PIVX/pull/1468