### PR TITLE
[Upstream][Net] Add support for dnsseeds with option to filter by servicebits

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -25,6 +25,14 @@ struct SeedSpec6 {
 
 #include "chainparamsseeds.h"
 
+std::string CDNSSeedData::getHost(uint64_t requiredServiceBits) const {
+    //use default host for non-filter-capable seeds or if we use the default service bits (NODE_NETWORK)
+    if (!supportsServiceBitsFiltering || requiredServiceBits == NODE_NETWORK)
+        return host;
+
+    return strprintf("x%x.%s", requiredServiceBits, host);
+}
+
 /**
  * Main network
  */
@@ -250,6 +258,7 @@ public:
         assert(hashGenesisBlock == uint256("0000039a711dba61e12c29fb86542fa059e9616aafe9b4c61e065d393f31535e"));
         assert(genesis.hashMerkleRoot == uint256("4dc798fa29a037570075a87a39c9a54c210f005c4c59c72f32036a87273f4cf8"));
 
+        // nodes with support for servicebits filtering should be at the top
         vSeeds.push_back(CDNSSeedData("seed.dapscoin.com", "seed.dapscoin.com"));        // Single node address
         vSeeds.push_back(CDNSSeedData("seed1.dapscoin.com", "seed1.dapscoin.com"));        // Single node address
         vSeeds.push_back(CDNSSeedData("seed2.dapscoin.com", "seed2.dapscoin.com"));        // Single node address
@@ -373,6 +382,7 @@ public:
 
         vFixedSeeds.clear();
         vSeeds.clear();
+        // nodes with support for servicebits filtering should be at the top
         vSeeds.push_back(CDNSSeedData("192.168.2.202", "192.168.2.202"));
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 139); // Testnet dapscoin addresses start with 'x' or 'y'

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -19,9 +19,12 @@
 
 typedef unsigned char MessageStartChars[MESSAGE_START_SIZE];
 
-struct CDNSSeedData {
+class CDNSSeedData {
+public:
     std::string name, host;
-    CDNSSeedData(const std::string& strName, const std::string& strHost) : name(strName), host(strHost) {}
+    bool supportsServiceBitsFiltering;
+    std::string getHost(uint64_t requiredServiceBits) const;
+    CDNSSeedData(const std::string& strName, const std::string& strHost, bool supportsServiceBitsFilteringIn = false) : name(strName), host(strHost), supportsServiceBitsFiltering(supportsServiceBitsFilteringIn) {}
 };
 
 /**

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1219,11 +1219,12 @@ void ThreadDNSAddressSeed() {
         } else {
             vector <CNetAddr> vIPs;
             vector <CAddress> vAdd;
-            if (LookupHost(seed.host.c_str(), vIPs, 0, true)) {
+            uint64_t requiredServiceBits = NODE_NETWORK;
+            if (LookupHost(seed.getHost(requiredServiceBits).c_str(), vIPs, 0, true)) {
                 for (CNetAddr & ip : vIPs)
                 {
                     int nOneDay = 24 * 3600;
-                    CAddress addr = CAddress(CService(ip, Params().GetDefaultPort()));
+                    CAddress addr = CAddress(CService(ip, Params().GetDefaultPort()), requiredServiceBits);
                     addr.nTime =
                             GetTime() - 3 * nOneDay - GetRand(4 * nOneDay); // use a random age between 3 and 7 days old
                     vAdd.push_back(addr);


### PR DESCRIPTION
> Backport of [bitcoin#8083](https://github.com/bitcoin/bitcoin/pull/8083)
> 
> This adds the ability to filter DNS seed requests by service bit, but does not actually implement any filtering other than the default `NODE_NETWORK` (for now). Further related upstream backports will follow.

from https://github.com/PIVX-Project/PIVX/pull/1452