### PR TITLE
[Upstream][Depends] Update OpenSSL download URL

### DIFF
--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,6 +1,6 @@
 package=openssl
 $(package)_version=1.0.1k
-$(package)_download_path=https://www.openssl.org/source
+$(package)_download_path=https://www.openssl.org/source/old
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c
 


### PR DESCRIPTION
> The URL for OpenSSL 1.0.1k has changed, so update it here.

from https://github.com/PIVX-Project/PIVX/pull/1483