### PR TITLE
[Upstream][GUI] ClientModel try to initialize cacheTip if it's null.

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -83,9 +83,13 @@ QString ClientModel::getMasternodeCountString() const
     return tr("Total: %1 (IPv4: %2 / IPv6: %3 / Tor: %4 / Unknown: %5)").arg(QString::number((int)mnodeman.size())).arg(QString::number((int)ipv4)).arg(QString::number((int)ipv6)).arg(QString::number((int)onion)).arg(QString::number((int)nUnknown));
 }
 
-int ClientModel::getNumBlocks() const
+int ClientModel::getNumBlocks()
 {
-    return cacheTip == nullptr ? 0 : cacheTip->nHeight;
+    if (!cacheTip) {
+        cacheTip = WITH_LOCK(cs_main, return chainActive.Tip(););
+    }
+
+    return cacheTip ? cacheTip->nHeight : 0;
 }
 
 int ClientModel::getNumBlocksAtStartup()

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -59,7 +59,7 @@ public:
     QString getMasternodeCountString() const;
 
     // from cached block index
-    int getNumBlocks() const;
+    int getNumBlocks();
     QDateTime getLastBlockDate() const;
     QString getLastBlockHash() const;
     int getChainHeight() const;
@@ -94,7 +94,7 @@ private:
     PeerTableModel* peerTableModel;
     BanTableModel *banTableModel;
 
-    const CBlockIndex* cacheTip;
+    const CBlockIndex* cacheTip{nullptr};
     QString cachedMasternodeCountString;
     bool cachedReindexing;
     bool cachedImporting;


### PR DESCRIPTION
> Fixing cacheTip not sync with the back-end information when the node has no connection and thereby there was no tip signal broadcasted to the front-end to update the cached tip. Showing a wrong chain height instead of the correct back-end tip.
> 
> This will only happen one time. Once the tip gets updated, it will not request it anymore from the back-end and only receive signals. Not locking `cs_main` anymore.

from https://github.com/PIVX-Project/PIVX/pull/1487