### PR TITLE
[UI] Less Freezing (pt. 1)

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1167,7 +1167,7 @@ void BitcoinGUI::setNumBlocks(int count)
     }
     if (count == 0) {
         blockCount->setText(tr("Loading Blocks..."));
-    } else if (IsInitialBlockDownload()) {
+    } else if (clientModel->inInitialBlockDownload()) {
         blockCount->setText(tr("Syncing Blocks..."));
     } else {
         blockCount->setText(tr("%n Blocks", "", count));
@@ -1326,7 +1326,7 @@ void BitcoinGUI::setStakingStatus()
         stakingAction->setIcon(QIcon(":/icons/staking_inactive"));
         return;
     }
-    if (IsInitialBlockDownload()) {
+    if (clientModel->inInitialBlockDownload()) {
         LogPrint("staking","Checking Staking Status: Syncing...\n");
         stakingState->setText(tr("Syncing Blocks..."));
         stakingState->setToolTip("Syncing Blocks");

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -120,15 +120,6 @@ QString ClientModel::getLastBlockHash() const
     return QString::fromStdString(nHash.GetHex());
 }
 
-int ClientModel::getChainHeight() const
-{
-    LOCK(cs_main);
-    if (chainActive.Tip())
-        return chainActive.Tip()->nHeight;
-    else 
-        return 0;
-}
-
 double ClientModel::getVerificationProgress() const
 {
     return Checkpoints::GuessVerificationProgress(cacheTip);

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -62,7 +62,6 @@ public:
     int getNumBlocks();
     QDateTime getLastBlockDate() const;
     QString getLastBlockHash() const;
-    int getChainHeight() const;
     double getVerificationProgress() const;
 
     quint64 getTotalBytesRecv() const;

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -330,7 +330,7 @@ void OverviewPage::showBlockSync(bool fShow)
     int count = clientModel->getNumBlocks();
     ui->labelBlockCurrent->setText(QString::number(count));
 
-    if (count == 0 && isSyncingBlocks){
+    if (count == 0 || clientModel->inInitialBlockDownload()){
         ui->labelBlockCurrent->setText("???");
         ui->labelBlockStatus->setText("(loading)");
         ui->labelBlockStatus->setToolTip("The displayed information may be out of date. Your wallet automatically synchronizes with the DAPS network after a connection is established, but this process has not completed yet.");

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -330,12 +330,7 @@ void OverviewPage::showBlockSync(bool fShow)
     int count = clientModel->getNumBlocks();
     ui->labelBlockCurrent->setText(QString::number(count));
 
-    if (count == 0 || clientModel->inInitialBlockDownload()){
-        ui->labelBlockCurrent->setText("???");
-        ui->labelBlockStatus->setText("(loading)");
-        ui->labelBlockStatus->setToolTip("The displayed information may be out of date. Your wallet automatically synchronizes with the DAPS network after a connection is established, but this process has not completed yet.");
-        ui->labelBlockCurrent->setAlignment((Qt::AlignRight|Qt::AlignVCenter));
-    } else if (isSyncingBlocks){
+    if (isSyncingBlocks){
         ui->labelBlockStatus->setText("(syncing)");
         ui->labelBlockStatus->setToolTip("The displayed information may be out of date. Your wallet automatically synchronizes with the DAPS network after a connection is established, but this process has not completed yet.");
         ui->labelBlockCurrent->setAlignment((Qt::AlignRight|Qt::AlignVCenter));


### PR DESCRIPTION
Instead of locking cs_main with IsInitialBlockDownload() we've switched to clientModel->inInitialBlockDownload() due to changes allowed by #133/#137

Also, remove the (loading) text added on overview as a temp fix to eliminate user confusion.\
Some users in the test group thought they had lost their chain data due to the 0 being shown - this is no longer displayed. The loading statuses may be introduced at a later date but more informatively and to match in all area (ie. Network Status blocks status of syncing/synced should show the same as Overview - currently block count is shown but not if synced/syncing for easier access to this information without changing tabs.)