### PR TITLE
[Upstream] GUI: Peer table: Visualize inbound/outbound state for every row

### DIFF
--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -162,7 +162,8 @@ QVariant PeerTableModel::data(const QModelIndex& index, int role) const
     if (role == Qt::DisplayRole) {
         switch (index.column()) {
         case Address:
-            return QString::fromStdString(rec->nodeStats.addrName);
+            // prepend to peer address down-arrow symbol for inbound connection and up-arrow for outbound connection
+            return QString(rec->nodeStats.fInbound ? "↓ " : "↑ ") + QString::fromStdString(rec->nodeStats.addrName);
         case Subversion:
             return QString::fromStdString(rec->nodeStats.cleanSubVer);
         case Ping:


### PR DESCRIPTION
> Fixes #13483
> 
> The address in the network peer table is prefixed with an up-arrow symbolizing an outbound connection, or an down-array symbolizing an inbound connection. See screenshot.
> 
> The user has an easy visual confirmation about the connection direction state. I really like it :)
> Impact to columns sorting is grouping by inbound/outbound first, which in my opinion is an advantage, too.
> ![bildschirmfoto](https://user-images.githubusercontent.com/8447873/41862752-13803eb2-78a5-11e8-9126-a52385f5ec19.png)

![image](https://user-images.githubusercontent.com/2319897/81010235-f003c580-8e23-11ea-8377-e608f4c5678a.png)

from https://github.com/bitcoin/bitcoin/pull/13537