### PR TITLE
[Upstream] build: remove redundant sed patching

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -165,7 +165,6 @@ define $(package)_preprocess_cmds
   sed -i.old "s/src_plugins.depends = src_sql src_network/src_plugins.depends = src_network/" qtbase/src/src.pro && \
   sed -i.old "s|X11/extensions/XIproto.h|X11/X.h|" qtbase/src/plugins/platforms/xcb/qxcbxsettings.cpp && \
   sed -i.old -e 's/if \[ "$$$$XPLATFORM_MAC" = "yes" \]; then xspecvals=$$$$(macSDKify/if \[ "$$$$BUILD_ON_MAC" = "yes" \]; then xspecvals=$$$$(macSDKify/' -e 's|/bin/pwd|pwd|' qtbase/configure && \
-  sed -i.old 's/CGEventCreateMouseEvent(0, kCGEventMouseMoved, pos, 0)/CGEventCreateMouseEvent(0, kCGEventMouseMoved, pos, kCGMouseButtonLeft)/' qtbase/src/plugins/platforms/cocoa/qcocoacursor.mm && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/Info.plist.lib qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f qtbase/mkspecs/macx-clang/Info.plist.app qtbase/mkspecs/macx-clang-linux/ &&\

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -163,7 +163,6 @@ define $(package)_preprocess_cmds
   sed -i.old "s|updateqm.commands = \$$$$\$$$$LRELEASE|updateqm.commands = $($(package)_extract_dir)/qttools/bin/lrelease|" qttranslations/translations/translations.pro && \
   sed -i.old "/updateqm.depends =/d" qttranslations/translations/translations.pro && \
   sed -i.old "s/src_plugins.depends = src_sql src_network/src_plugins.depends = src_network/" qtbase/src/src.pro && \
-  sed -i.old "s|X11/extensions/XIproto.h|X11/X.h|" qtbase/src/plugins/platforms/xcb/qxcbxsettings.cpp && \
   sed -i.old -e 's/if \[ "$$$$XPLATFORM_MAC" = "yes" \]; then xspecvals=$$$$(macSDKify/if \[ "$$$$BUILD_ON_MAC" = "yes" \]; then xspecvals=$$$$(macSDKify/' -e 's|/bin/pwd|pwd|' qtbase/configure && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/Info.plist.lib qtbase/mkspecs/macx-clang-linux/ &&\


### PR DESCRIPTION
> While looking at #16838 I found at least two cases of `sed` patching in depends that now seems to be redundant. There's possibly a [third case](https://github.com/bitcoin/bitcoin/pull/16837#discussion_r322842701), but I haven't looked into that enough yet.
> 
> Patching `0` -> `kCGMouseButtonLeft` should not be required, as [`kCGMouseButtonLeft`](https://code.qt.io/cgit/qt/qtbase.git/tree/src/plugins/platforms/cocoa/qcocoacursor.mm?h=5.9#n82) has been used in the `cocoa/qcocoacursor.mm` source for a while.
> 
> The include we were modifying in [`src/plugins/platforms/xcb/qxcbxsettings.cpp`](https://code.qt.io/cgit/qt/qtbase.git/tree/src/plugins/platforms/xcb/qxcbxsettings.cpp?h=5.9#n47) was removed in [this commit](https://code.qt.io/cgit/qt/qtbase.git/commit/src/plugins/platforms/xcb/qxcbxsettings.cpp?h=5.9&id=78731b434e0e99ad108601249108e12d8a49c350).

from https://github.com/bitcoin/bitcoin/pull/16879