### PR TITLE
[Upstream] [GUI][Bug] Fix "Select all" / "Unselect all" logic in coincontrol

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -187,20 +187,21 @@ void CoinControlDialog::buttonBoxClicked(QAbstractButton* button)
 // (un)select all
 void CoinControlDialog::buttonSelectAllClicked()
 {
-    Qt::CheckState state = Qt::Checked;
-    for (int i = 0; i < ui->treeWidget->topLevelItemCount(); i++) {
-        if (ui->treeWidget->topLevelItem(i)->checkState(COLUMN_CHECKBOX) != Qt::Unchecked) {
-            state = Qt::Unchecked;
-            break;
-        }
-    }
+    // "Select all": if some entry is unchecked, then check it
+    // "Unselect all": if some entry is checked, then uncheck it
+    Qt::CheckState wantedState = fSelectAllToggled ? Qt::Checked : Qt::Unchecked;
     ui->treeWidget->setEnabled(false);
     for (int i = 0; i < ui->treeWidget->topLevelItemCount(); i++)
-        if (ui->treeWidget->topLevelItem(i)->checkState(COLUMN_CHECKBOX) != state)
-            ui->treeWidget->topLevelItem(i)->setCheckState(COLUMN_CHECKBOX, state);
+        if (ui->treeWidget->topLevelItem(i)->checkState(COLUMN_CHECKBOX) != wantedState)
+            ui->treeWidget->topLevelItem(i)->setCheckState(COLUMN_CHECKBOX, wantedState);
     ui->treeWidget->setEnabled(true);
-    if (state == Qt::Unchecked)
+    if (!fSelectAllToggled) {
         coinControl->UnSelectAll(); // just to be sure
+        ui->pushButtonSelectAll->setText(tr("Select all"));
+    } else {
+        ui->pushButtonSelectAll->setText(tr("Unselect all"));
+    }
+    fSelectAllToggled = !fSelectAllToggled;
     CoinControlDialog::updateLabels(model, this);
     updateDialogLabels();
 }

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -63,6 +63,7 @@ private:
     int sortColumn;
     Qt::SortOrder sortOrder;
     bool fMultisigEnabled;
+    bool fSelectAllToggled{true};     // false when pushButtonSelectAll text is "Unselect All"
 
     QMenu* contextMenu;
     QTreeWidgetItem* contextMenuItem;


### PR DESCRIPTION
> Prioritize the action described by the button:
> 
> * if "Select All", then verify that all entries are checked, otherwise check them
> * if "Unselect All", then verify that all entries are unchecked, otherwise uncheck them.
> 
> Closes #1592
> 
> **Note**: if we had just prioritized `Qt::Unchecked` at the beginning, instead of `Qt::Checked`, without taking into account the status/text of the button, we would have solved 1592, but we'd have another bug where, using first "Select All" to check all entries, and then manually deselecting some entry, results in a successive "Unselect All" still behaving like "Select All".

from https://github.com/PIVX-Project/PIVX/pull/1595

[for when we restore Coin Control]