### PR TITLE
[Upstream] [Trivial] Remove CMasternode::SliceHash

### DIFF
--- a/src/masternode.h
+++ b/src/masternode.h
@@ -223,13 +223,6 @@ public:
 
     bool UpdateFromNewBroadcast(CMasternodeBroadcast& mnb);
 
-    inline uint64_t SliceHash(uint256& hash, int slice)
-    {
-        uint64_t n = 0;
-        memcpy(&n, &hash + slice * 64, 64);
-        return n;
-    }
-
     void Check(bool forceCheck = false);
 
     bool IsBroadcastedWithin(int seconds)


### PR DESCRIPTION
Removes un-used function SliceHash (which is also buggy and overflowing,
trying to copy 64 bytes to a destination buffer having only 8 bytes).

from https://github.com/PIVX-Project/PIVX/pull/1513