### PR TITLE
Logging/Error MsgBoxes

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -293,6 +293,13 @@ void SendCoinsDialog::sendTx() {
                         msgBox.setText(msg);
                         msgBox.setStyleSheet(GUIUtil::loadStyleSheet());
                         msgBox.exec();
+                    } else {
+                        QMessageBox msgBox;
+                        msgBox.setWindowTitle("Sweeping Transaction Creation Error");
+                        msgBox.setText(QString("Sweeping transaction creation failed due to an internal error. Please try again later."));
+                        msgBox.setStyleSheet(GUIUtil::loadStyleSheet());
+                        msgBox.setIcon(QMessageBox::Critical);
+                        msgBox.exec();
                     }
                 } catch (const std::exception& err1) {
                     nReserveBalance = backupReserve;

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -275,7 +275,7 @@ void SendCoinsDialog::sendTx() {
         std::string errMes(err.what());
         if (errMes.find("You have attempted to send more than 50 UTXOs in a single transaction") != std::string::npos) {
             QMessageBox::StandardButton reply;
-            reply = QMessageBox::question(this, "Transaction Size Too Large", QString(err.what()) + QString("\n Do you want to combine small UTXOs into a larger one?"), QMessageBox::Yes|QMessageBox::No);
+            reply = QMessageBox::question(this, "Transaction Size Too Large", QString(err.what()) + QString("\n\nDo you want to combine small UTXOs into a larger one?"), QMessageBox::Yes|QMessageBox::No);
             if (reply == QMessageBox::Yes) {
                 CAmount backupReserve = nReserveBalance;
                 try {
@@ -299,7 +299,7 @@ void SendCoinsDialog::sendTx() {
                     QMessageBox msgBox;
                     LogPrintf("ERROR:%s: %s\n", __func__, err1.what());
                     msgBox.setWindowTitle("Sweeping Transaction Creation Error");
-                    msgBox.setText(QString("Sweeping transaction failed due to an internal error! Please try again later!"));
+                    msgBox.setText(QString("Sweeping transaction creation failed due to an internal error. Please try again later."));
                     msgBox.setStyleSheet(GUIUtil::loadStyleSheet());
                     msgBox.setIcon(QMessageBox::Critical);
                     msgBox.exec();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5088,6 +5088,7 @@ bool CWallet::CreateSweepingTransaction(CAmount target, CAmount threshold, uint3
     if (GetSpendableBalance() < 5 * COIN) {
         return false;
     }
+    LogPrintf("Attempting to create a sweeping transaction\n");
     CAmount total = 0;
     std::vector<COutput> vCoins;
     COutput lowestLarger(NULL, 0, 0, false);
@@ -5360,7 +5361,6 @@ void CWallet::AutoCombineDust()
         }
         return;
     }
-    LogPrintf("Creating a sweeping transaction\n");
     CreateSweepingTransaction(nAutoCombineThreshold, nAutoCombineThreshold, GetAdjustedTime());
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2773,7 +2773,7 @@ bool CWallet::CreateTransactionBulletProof(const CKey& txPrivDes, const CPubKey&
                                 strFailReason = "Insufficient reserved funds! Your wallet is staking with a reserve balance of " + ValueFromAmountToString(nReserveBalance) + " less than the sending amount " + ValueFromAmountToString(nTotalValue);
                         } else if (setCoins.size() > MAX_TX_INPUTS) {
                             //max inputs
-                            strFailReason = _("You have attempted to send more than 50 UTXOs in a single transaction. This is a rare occurrence, and to work around this limitation, please either lower the total amount of the transaction, or send two separate transactions with 50% of your total desired amount.");
+                            strFailReason = _("You have attempted to send more than 50 UTXOs in a single transaction. To work around this limitation, please either lower the total amount of the transaction or send two separate transactions with 50% of your total desired amount.");
                         } else {
                             //other
                             strFailReason = _("Error in CreateTransactionBulletProof. Please try again.");


### PR DESCRIPTION
- Update "Transaction Size Too Large" msgbox
- Add additional error msgbox as the one in catch was not displaying (failed sweeping transaction)
- Update text for work around UTXO limit msgbox
- Updated logging for sweeping transactions