### PR TITLE
[Upstream] build: macOS toolchain update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ env:
 # No wallet
 #    - HOST=x86_64-unknown-linux-gnu PACKAGES="python3" DEP_OPTS="NO_WALLET=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
 # Cross-Mac
-    - HOST=x86_64-apple-darwin16 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev" BITCOIN_CONFIG="--enable-reduce-exports" OSX_SDK=10.11 GOAL="deploy"
+    - HOST=x86_64-apple-darwin16 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev" BITCOIN_CONFIG="--enable-reduce-exports" OSX_SDK=10.14 GOAL="deploy"
 
 before_install:
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")

--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -189,7 +189,7 @@ then
 fi
 
 # Check for OSX SDK
-if [[ ! -e "gitian-builder/inputs/MacOSX10.11.sdk.tar.gz" && $osx == true ]]
+if [[ ! -e "gitian-builder/inputs/MacOSX10.14.sdk.tar.gz" && $osx == true ]]
 then
     echo "Cannot build for OSX, SDK does not exist. Will build for other OSes"
     osx=false

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -31,7 +31,7 @@ remotes:
 - "url": "https://github.com/dapscoin-project/dapscoin.git"
   "dir": "dapscoin"
 files:
-- "MacOSX10.11.sdk.tar.gz"
+- "MacOSX10.14.sdk.tar.gz"
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="x86_64-apple-darwin16"
@@ -87,7 +87,7 @@ script: |
   BASEPREFIX=`pwd`/depends
 
   mkdir -p ${BASEPREFIX}/SDKs
-  tar -C ${BASEPREFIX}/SDKs -xf ${BUILD_DIR}/MacOSX10.11.sdk.tar.gz
+  tar -C ${BASEPREFIX}/SDKs -xf ${BUILD_DIR}/MacOSX10.14.sdk.tar.gz
 
   # Build dependencies for each host
   for i in $HOSTS; do

--- a/contrib/macdeploy/README.md
+++ b/contrib/macdeploy/README.md
@@ -1,15 +1,135 @@
-### MacDeploy ###
+# MacOS Deployment
 
-For Snow Leopard (which uses [Python 2.6](http://www.python.org/download/releases/2.6/)), you will need the param_parser package:
+The `macdeployqtplus` script should not be run manually. Instead, after building as usual:
 
-	sudo easy_install argparse
+```bash
+make deploy
+```
 
-This script should not be run manually, instead, after building as usual:
+During the deployment process, the disk image window will pop up briefly
+when the fancy settings are applied. This is normal, please do not interfere,
+the process will unmount the DMG and cleanup before finishing.
 
-	make deploy
+When complete, it will have produced `Bitcoin-Qt.dmg`.
 
-During the process, the disk image window will pop up briefly where the fancy
-settings are applied. This is normal, please do not interfere.
+## SDK Extraction
 
-When finished, it will produce `Dapscoin-Qt.dmg`.
+`Xcode.app` is packaged in a `.xip` archive.
+This makes the SDK less-trivial to extract on non-macOS machines.
+One approach (tested on Debian Buster) is outlined below:
 
+```bash
+
+apt install clang cpio git liblzma-dev libxml2-dev libssl-dev make
+
+git clone https://github.com/tpoechtrager/xar
+pushd xar/xar
+./configure
+make
+make install
+popd
+
+git clone https://github.com/NiklasRosenstein/pbzx
+pushd pbzx
+clang -llzma -lxar pbzx.c -o pbzx -Wl,-rpath=/usr/local/lib
+popd
+
+xar -xf Xcode_10.2.1.xip -C .
+
+./pbzx/pbzx -n Content | cpio -i
+
+find Xcode.app -type d -name MacOSX.sdk -execdir sh -c 'tar -c MacOSX.sdk/ | gzip -9n > /MacOSX10.14.sdk.tar.gz' \;
+```
+
+on macOS the process is more straightforward:
+
+```bash
+xip -x Xcode_10.2.1.xip
+tar -C Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/ -czf MacOSX10.14.sdk.tar.gz MacOSX.sdk
+```
+
+Our previously used macOS SDK (`MacOSX10.11.sdk`) can be extracted from
+[Xcode 7.3.1 dmg](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_7.3.1/Xcode_7.3.1.dmg).
+The script [`extract-osx-sdk.sh`](./extract-osx-sdk.sh) automates this. First
+ensure the DMG file is in the current directory, and then run the script. You
+may wish to delete the `intermediate 5.hfs` file and `MacOSX10.11.sdk` (the
+directory) when you've confirmed the extraction succeeded.
+
+```bash
+apt-get install p7zip-full sleuthkit
+contrib/macdeploy/extract-osx-sdk.sh
+rm -rf 5.hfs MacOSX10.11.sdk
+```
+
+## Deterministic macOS DMG Notes
+Working macOS DMGs are created in Linux by combining a recent `clang`, the Apple
+`binutils` (`ld`, `ar`, etc) and DMG authoring tools.
+
+Apple uses `clang` extensively for development and has upstreamed the necessary
+functionality so that a vanilla clang can take advantage. It supports the use of `-F`,
+`-target`, `-mmacosx-version-min`, and `--sysroot`, which are all necessary when
+building for macOS.
+
+Apple's version of `binutils` (called `cctools`) contains lots of functionality missing in the
+FSF's `binutils`. In addition to extra linker options for frameworks and sysroots, several
+other tools are needed as well such as `install_name_tool`, `lipo`, and `nmedit`. These
+do not build under Linux, so they have been patched to do so. The work here was used as
+a starting point: [mingwandroid/toolchain4](https://github.com/mingwandroid/toolchain4).
+
+In order to build a working toolchain, the following source packages are needed from
+Apple: `cctools`, `dyld`, and `ld64`.
+
+These tools inject timestamps by default, which produce non-deterministic binaries. The
+`ZERO_AR_DATE` environment variable is used to disable that.
+
+This version of `cctools` has been patched to use the current version of `clang`'s headers
+and its `libLTO.so` rather than those from `llvmgcc`, as it was originally done in `toolchain4`.
+
+To complicate things further, all builds must target an Apple SDK. These SDKs are free to
+download, but not redistributable. To obtain it, register for an Apple Developer Account,
+then download [Xcode 10.2.1](https://download.developer.apple.com/Developer_Tools/Xcode_10.2.1/Xcode_10.2.1.xip).
+
+This file is many gigabytes in size, but most (but not all) of what we need is
+contained only in a single directory:
+
+```bash
+Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk
+```
+
+See the SDK Extraction notes above for how to obtain it.
+
+The Gitian descriptors build 2 sets of files: Linux tools, then Apple binaries which are
+created using these tools. The build process has been designed to avoid including the
+SDK's files in Gitian's outputs. All interim tarballs are fully deterministic and may be freely
+redistributed.
+
+`genisoimage` is used to create the initial DMG. It is not deterministic as-is, so it has been
+patched. A system `genisoimage` will work fine, but it will not be deterministic because
+the file-order will change between invocations. The patch can be seen here: [cdrkit-deterministic.patch](https://github.com/bitcoin/bitcoin/blob/master/depends/patches/native_cdrkit/cdrkit-deterministic.patch).
+No effort was made to fix this cleanly, so it likely leaks memory badly, however it's only used for
+a single invocation, so that's no real concern.
+
+`genisoimage` cannot compress DMGs, so afterwards, the DMG tool from the
+`libdmg-hfsplus` project is used to compress it. There are several bugs in this tool and its
+maintainer has seemingly abandoned the project.
+
+The DMG tool has the ability to create DMGs from scratch as well, but this functionality is
+broken. Only the compression feature is currently used. Ideally, the creation could be fixed
+and `genisoimage` would no longer be necessary.
+
+Background images and other features can be added to DMG files by inserting a
+`.DS_Store` before creation. This is generated by the script `contrib/macdeploy/custom_dsstore.py`.
+
+As of OS X 10.9 Mavericks, using an Apple-blessed key to sign binaries is a requirement in
+order to satisfy the new Gatekeeper requirements. Because this private key cannot be
+shared, we'll have to be a bit creative in order for the build process to remain somewhat
+deterministic. Here's how it works:
+
+- Builders use Gitian to create an unsigned release. This outputs an unsigned DMG which
+  users may choose to bless and run. It also outputs an unsigned app structure in the form
+  of a tarball, which also contains all of the tools that have been previously (deterministically)
+  built in order to create a final DMG.
+- The Apple keyholder uses this unsigned app to create a detached signature, using the
+  script that is also included there. Detached signatures are available from this [repository](https://github.com/bitcoin-core/bitcoin-detached-sigs).
+- Builders feed the unsigned app + detached signature back into Gitian. It uses the
+  pre-built tools to recombine the pieces into a deterministic DMG.

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -1,9 +1,8 @@
 OSX_MIN_VERSION=10.12
 OSX_SDK_VERSION=10.14
 OSX_SDK=$(SDK_PATH)/MacOSX$(OSX_SDK_VERSION).sdk
-LD64_VERSION=253.9
-darwin_CC=clang -target $(host) -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(OSX_SDK) -mlinker-version=$(LD64_VERSION)
-darwin_CXX=clang++ -target $(host) -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(OSX_SDK) -mlinker-version=$(LD64_VERSION) -stdlib=libc++
+darwin_CC=clang -target $(host) -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(OSX_SDK)
+darwin_CXX=clang++ -target $(host) -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(OSX_SDK) -stdlib=libc++
 
 darwin_CFLAGS=-pipe
 darwin_CXXFLAGS=$(darwin_CFLAGS)

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -1,5 +1,5 @@
 OSX_MIN_VERSION=10.12
-OSX_SDK_VERSION=10.11
+OSX_SDK_VERSION=10.14
 OSX_SDK=$(SDK_PATH)/MacOSX$(OSX_SDK_VERSION).sdk
 LD64_VERSION=253.9
 darwin_CC=clang -target $(host) -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(OSX_SDK) -mlinker-version=$(LD64_VERSION)

--- a/depends/packages/native_cctools.mk
+++ b/depends/packages/native_cctools.mk
@@ -4,11 +4,11 @@ $(package)_download_path=https://github.com/theuni/cctools-port/archive
 $(package)_file_name=$($(package)_version).tar.gz
 $(package)_sha256_hash=a09c9ba4684670a0375e42d9d67e7f12c1f62581a27f28f7c825d6d7032ccc6a
 $(package)_build_subdir=cctools
-$(package)_clang_version=3.7.1
-$(package)_clang_download_path=https://llvm.org/releases/$($(package)_clang_version)
+$(package)_clang_version=6.0.1
+$(package)_clang_download_path=https://releases.llvm.org/$($(package)_clang_version)
 $(package)_clang_download_file=clang+llvm-$($(package)_clang_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
 $(package)_clang_file_name=clang-llvm-$($(package)_clang_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-$(package)_clang_sha256_hash=99b28a6b48e793705228a390471991386daa33a9717cd9ca007fcdde69608fd9
+$(package)_clang_sha256_hash=fa5416553ca94a8c071a27134c094a5fb736fe1bd0ecc5ef2d9bc02754e1bef0
 $(package)_extra_sources=$($(package)_clang_file_name)
 
 define $(package)_fetch_cmds
@@ -21,12 +21,9 @@ define $(package)_extract_cmds
   echo "$($(package)_sha256_hash)  $($(package)_source)" > $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   echo "$($(package)_clang_sha256_hash)  $($(package)_source_dir)/$($(package)_clang_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   $(build_SHA256SUM) -c $($(package)_extract_dir)/.$($(package)_file_name).hash && \
-  mkdir -p toolchain/bin toolchain/lib/clang/3.5/include && \
+  mkdir -p toolchain/bin toolchain/lib/clang/$($(package)_clang_version)/include && \
   tar --no-same-owner --strip-components=1 -C toolchain -xf $($(package)_source_dir)/$($(package)_clang_file_name) && \
   rm -f toolchain/lib/libc++abi.so* && \
-  echo "#!/bin/sh" > toolchain/bin/$(host)-dsymutil && \
-  echo "exit 0" >> toolchain/bin/$(host)-dsymutil && \
-  chmod +x toolchain/bin/$(host)-dsymutil && \
   tar --no-same-owner --strip-components=1 -xf $($(package)_source)
 endef
 

--- a/depends/packages/native_cctools.mk
+++ b/depends/packages/native_cctools.mk
@@ -1,42 +1,55 @@
 package=native_cctools
-$(package)_version=807d6fd1be5d2224872e381870c0a75387fe05e6
-$(package)_download_path=https://github.com/theuni/cctools-port/archive
+$(package)_version=3764b223c011574971ee3ae09ce968ba5dc2f00f
+$(package)_download_path=https://github.com/tpoechtrager/cctools-port/archive
 $(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=a09c9ba4684670a0375e42d9d67e7f12c1f62581a27f28f7c825d6d7032ccc6a
+$(package)_sha256_hash=3e35907bf376269a844df08e03cbb43e345c88125374f2228e03724b5f9a2a04
 $(package)_build_subdir=cctools
 $(package)_clang_version=6.0.1
 $(package)_clang_download_path=https://releases.llvm.org/$($(package)_clang_version)
 $(package)_clang_download_file=clang+llvm-$($(package)_clang_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
 $(package)_clang_file_name=clang-llvm-$($(package)_clang_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
 $(package)_clang_sha256_hash=fa5416553ca94a8c071a27134c094a5fb736fe1bd0ecc5ef2d9bc02754e1bef0
+
+$(package)_libtapi_version=3efb201881e7a76a21e0554906cf306432539cef
+$(package)_libtapi_download_path=https://github.com/tpoechtrager/apple-libtapi/archive
+$(package)_libtapi_download_file=$($(package)_libtapi_version).tar.gz
+$(package)_libtapi_file_name=$($(package)_libtapi_version).tar.gz
+$(package)_libtapi_sha256_hash=380c1ca37cfa04a8699d0887a8d3ee1ad27f3d08baba78887c73b09485c0fbd3
+
 $(package)_extra_sources=$($(package)_clang_file_name)
+$(package)_extra_sources += $($(package)_libtapi_file_name)
 
 define $(package)_fetch_cmds
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_download_file),$($(package)_file_name),$($(package)_sha256_hash)) && \
-$(call fetch_file,$(package),$($(package)_clang_download_path),$($(package)_clang_download_file),$($(package)_clang_file_name),$($(package)_clang_sha256_hash))
+$(call fetch_file,$(package),$($(package)_clang_download_path),$($(package)_clang_download_file),$($(package)_clang_file_name),$($(package)_clang_sha256_hash)) && \
+$(call fetch_file,$(package),$($(package)_libtapi_download_path),$($(package)_libtapi_download_file),$($(package)_libtapi_file_name),$($(package)_libtapi_sha256_hash))
 endef
 
 define $(package)_extract_cmds
   mkdir -p $($(package)_extract_dir) && \
   echo "$($(package)_sha256_hash)  $($(package)_source)" > $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   echo "$($(package)_clang_sha256_hash)  $($(package)_source_dir)/$($(package)_clang_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  echo "$($(package)_libtapi_sha256_hash)  $($(package)_source_dir)/$($(package)_libtapi_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   $(build_SHA256SUM) -c $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   mkdir -p toolchain/bin toolchain/lib/clang/$($(package)_clang_version)/include && \
+  mkdir -p libtapi && \
+  tar --no-same-owner --strip-components=1 -C libtapi -xf $($(package)_source_dir)/$($(package)_libtapi_file_name) && \
   tar --no-same-owner --strip-components=1 -C toolchain -xf $($(package)_source_dir)/$($(package)_clang_file_name) && \
   rm -f toolchain/lib/libc++abi.so* && \
   tar --no-same-owner --strip-components=1 -xf $($(package)_source)
 endef
 
 define $(package)_set_vars
-$(package)_config_opts=--target=$(host) --disable-lto-support
-$(package)_ldflags+=-Wl,-rpath=\\$$$$$$$$\$$$$$$$$ORIGIN/../lib
-$(package)_cc=$($(package)_extract_dir)/toolchain/bin/clang
-$(package)_cxx=$($(package)_extract_dir)/toolchain/bin/clang++
+  $(package)_config_opts=--target=$(host) --disable-lto-support --with-libtapi=$($(package)_extract_dir)
+  $(package)_ldflags+=-Wl,-rpath=\\$$$$$$$$\$$$$$$$$ORIGIN/../lib
+  $(package)_cc=$($(package)_extract_dir)/toolchain/bin/clang
+  $(package)_cxx=$($(package)_extract_dir)/toolchain/bin/clang++
 endef
 
 define $(package)_preprocess_cmds
-  cd $($(package)_build_subdir); ./autogen.sh && \
-  sed -i.old "/define HAVE_PTHREADS/d" ld64/src/ld/InputFiles.h
+  CC=$($(package)_cc) CXX=$($(package)_cxx) INSTALLPREFIX=$($(package)_extract_dir) ./libtapi/build.sh && \
+  CC=$($(package)_cc) CXX=$($(package)_cxx) INSTALLPREFIX=$($(package)_extract_dir) ./libtapi/install.sh && \
+  sed -i.old "/define HAVE_PTHREADS/d" $($(package)_build_subdir)/ld64/src/ld/InputFiles.h
 endef
 
 define $(package)_config_cmds
@@ -49,6 +62,9 @@ endef
 
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install && \
+  mkdir -p $($(package)_staging_prefix_dir)/lib/ && \
+  cd $($(package)_extract_dir) && \
+  cp lib/libtapi.so.6 $($(package)_staging_prefix_dir)/lib/ && \
   cd $($(package)_extract_dir)/toolchain && \
   mkdir -p $($(package)_staging_prefix_dir)/lib/clang/$($(package)_clang_version)/include && \
   mkdir -p $($(package)_staging_prefix_dir)/bin $($(package)_staging_prefix_dir)/include && \

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -95,7 +95,6 @@ $(package)_config_opts_darwin += -device-option MAC_SDK_VERSION=$(OSX_SDK_VERSIO
 $(package)_config_opts_darwin += -device-option CROSS_COMPILE="$(host)-"
 $(package)_config_opts_darwin += -device-option MAC_MIN_VERSION=$(OSX_MIN_VERSION)
 $(package)_config_opts_darwin += -device-option MAC_TARGET=$(host)
-$(package)_config_opts_darwin += -device-option MAC_LD64_VERSION=$(LD64_VERSION)
 endif
 
 $(package)_config_opts_linux  = -qt-xkbcommon-x11

--- a/depends/patches/qt/mac-qmake.conf
+++ b/depends/patches/qt/mac-qmake.conf
@@ -18,7 +18,7 @@ QMAKE_APPLE_DEVICE_ARCHS=x86_64
 !host_build: QMAKE_CFLAGS += -target $${MAC_TARGET}
 !host_build: QMAKE_OBJECTIVE_CFLAGS += $$QMAKE_CFLAGS
 !host_build: QMAKE_CXXFLAGS += $$QMAKE_CFLAGS
-!host_build: QMAKE_LFLAGS += -target $${MAC_TARGET} -mlinker-version=$${MAC_LD64_VERSION}
+!host_build: QMAKE_LFLAGS += -target $${MAC_TARGET}
 QMAKE_AR = $${CROSS_COMPILE}ar cq
 QMAKE_RANLIB=$${CROSS_COMPILE}ranlib
 QMAKE_LIBTOOL=$${CROSS_COMPILE}libtool

--- a/doc/README_osx.md
+++ b/doc/README_osx.md
@@ -32,7 +32,7 @@ To obtain it, register for a developer account, then download the [Xcode 7.3.1 d
 This file is several gigabytes in size, but only a single directory inside is
 needed:
 ```
-Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk
+Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk
 ```
 
 Unfortunately, the usual linux tools (7zip, hpmount, loopback mount) are incapable of opening this file.
@@ -41,19 +41,19 @@ To create a tarball suitable for Gitian input, there are two options:
 Using Mac OS X, you can mount the dmg, and then create it with:
 ```
   $ hdiutil attach Xcode_7.3.1.dmg
-  $ tar -C /Volumes/Xcode/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/ -czf MacOSX10.11.sdk.tar.gz MacOSX10.11.sdk
+  $ tar -C /Volumes/Xcode/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/ -czf MacOSX10.14.sdk.tar.gz MacOSX10.14.sdk
 ```
 
 Alternatively, you can use 7zip and SleuthKit to extract the files one by one.
 The script contrib/macdeploy/extract-osx-sdk.sh automates this. First ensure
 the dmg file is in the current directory, and then run the script. You may wish
-to delete the intermediate 5.hfs file and MacOSX10.11.sdk (the directory) when
+to delete the intermediate 5.hfs file and MacOSX10.14.sdk (the directory) when
 you've confirmed the extraction succeeded.
 
 ```bash
 apt-get install p7zip-full sleuthkit
 contrib/macdeploy/extract-osx-sdk.sh
-rm -rf 5.hfs MacOSX10.11.sdk
+rm -rf 5.hfs MacOSX10.14.sdk
 ```
 
 The Gitian descriptors build 2 sets of files: Linux tools, then Apple binaries

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -1,125 +1,115 @@
-Mac OS X Build Instructions and Notes
-====================================
-This guide will show you how to build dapscoind (headless client) for OSX.
+# macOS Build Instructions and Notes
 
-Notes
------
+The commands in this guide should be executed in a Terminal application.
+The built-in one is located in
+```
+/Applications/Utilities/Terminal.app
+```
 
+## Preparation
+Install the macOS command line tools:
+
+```shell
+xcode-select --install
+```
+
+When the popup appears, click `Install`.
+
+Then install [Homebrew](https://brew.sh).
+
+## Dependencies
+```shell
+brew install automake berkeley-db4 libtool boost miniupnpc pkg-config python qt libevent qrencode
+```
+
+See [dependencies.md](dependencies.md) for a complete overview.
+
+If you want to build the disk image with `make deploy` (.dmg / optional), you need RSVG:
+```shell
+brew install librsvg
+```
+
+## Berkeley DB
+It is recommended to use Berkeley DB 4.8. If you have to build it yourself,
+you can use [this](/contrib/install_db4.sh) script to install it
+like so:
+
+```shell
+./contrib/install_db4.sh .
+```
+
+from the root of the repository.
+
+**Note**: You only need Berkeley DB if the wallet is enabled (see [*Disable-wallet mode*](/doc/build-osx.md#disable-wallet-mode)).
+
+## Build DAPSCoin Core
+
+1. Clone the DAPSCoin Core source code:
+    ```shell
+    git clone https://github.com/dapscoin/dapscoin
+    cd dapscoin
+    ```
+
+2.  Build DAPSCoin Core:
+
+    Configure and build the headless DAPSCoin Core binaries as well as the GUI (if Qt is found).
+
+    You can disable the GUI build by passing `--without-gui` to configure.
+    ```shell
+    ./autogen.sh
+    ./configure
+    make
+    ```
+
+3.  It is recommended to build and run the unit tests:
+    ```shell
+    make check
+    ```
+
+4.  You can also create a  `.dmg` that contains the `.app` bundle (optional):
+    ```shell
+    make deploy
+    ```
+
+## `disable-wallet` mode
+When the intention is to run only a P2P node without a wallet, DAPSCoin Core may be
+compiled in `disable-wallet` mode with:
+```shell
+./configure --disable-wallet
+```
+
+In this case there is no dependency on Berkeley DB 4.8.
+
+Mining is also possible in disable-wallet mode using the `getblocktemplate` RPC call.
+
+## Running
+DAPSCoin Core is now available at `./src/dapscoind`
+
+Before running, you may create an empty configuration file:
+```shell
+mkdir -p "/Users/${USER}/Library/Application Support/DAPSCoin"
+
+touch "/Users/${USER}/Library/Application Support/DAPSCoin/dapscoin.conf"
+
+chmod 600 "/Users/${USER}/Library/Application Support/DAPSCoin/dapscoin.conf"
+```
+
+The first time you run dapscoind, it will start downloading the blockchain. This process could
+take many hours, or even days on slower than average systems.
+
+You can monitor the download process by looking at the debug.log file:
+```shell
+tail -f $HOME/Library/Application\ Support/DAPSCoin/debug.log
+```
+
+## Other commands:
+```shell
+./src/dapscoind -daemon      # Starts the dapscoin daemon.
+./src/dapscoin-cli --help    # Outputs a list of command-line options.
+./src/dapscoin-cli help      # Outputs a list of RPC commands when the daemon is running.
+```
+
+## Notes
 * Tested on OS X 10.12 Sierra through macOS 10.15 Catalina on 64-bit Intel
-
-* All of the commands should be executed in a Terminal application. The
-built-in one is located in `/Applications/Utilities`.
-
-Preparation
------------
-
-You need to install XCode with all the options checked so that the compiler
-and everything is available in /usr not just /Developer. XCode should be
-available on your OS X installation media, but if not, you can get the
-current version from https://developer.apple.com/xcode/. If you install
-Xcode 4.3 or later, you'll need to install its command line tools. This can
-be done in `Xcode > Preferences > Downloads > Components` and generally must
-be re-done or updated every time Xcode is updated.
-
-There's also an assumption that you already have `git` installed. If
-not, it's the path of least resistance to install [Github for Mac](https://mac.github.com/)
-(OS X 10.7+) or
-[Git for OS X](https://code.google.com/p/git-osx-installer/). It is also
-available via Homebrew.
-
-You will also need to install [Homebrew](http://brew.sh) in order to install library
-dependencies.
-
-The installation of the actual dependencies is covered in the Instructions
-sections below.
-
-Instructions: Homebrew
-----------------------
-
-#### Install dependencies using Homebrew
-
-        brew install autoconf automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf qt5 libzmq
-
-### Building `dapscoind`
-
-1. Clone the github tree to get the source code and go into the directory.
-
-        git clone https://github.com/DAPScoin-Project/DAPScoin.git
-        cd DAPScoin
-
-2.  Build dapscoind:
-
-        ./autogen.sh
-        ./configure --with-gui=qt5
-        make
-3.  Make the Homebrew OpenSSL headers visible to the configure script  (do ```brew info openssl``` to find out why this is necessary, or if you use Homebrew with installation folders different from the default).
-
-        export LDFLAGS+=-L/usr/local/opt/openssl/lib
-        export CPPFLAGS+=-I/usr/local/opt/openssl/include
-
-4.  It is also a good idea to build and run the unit tests:
-
-        make check
-
-5.  (Optional) You can also install dapscoind to your path:
-
-        make install
-
-Use Qt Creator as IDE
-------------------------
-You can use Qt Creator as IDE, for debugging and for manipulating forms, etc.
-Download Qt Creator from http://www.qt.io/download/. Download the "community edition" and only install Qt Creator (uncheck the rest during the installation process).
-
-1. Make sure you installed everything through homebrew mentioned above
-2. Do a proper ./configure --with-gui=qt5 --enable-debug
-3. In Qt Creator do "New Project" -> Import Project -> Import Existing Project
-4. Enter "dapscoin-qt" as project name, enter src/qt as location
-5. Leave the file selection as it is
-6. Confirm the "summary page"
-7. In the "Projects" tab select "Manage Kits..."
-8. Select the default "Desktop" kit and select "Clang (x86 64bit in /usr/bin)" as compiler
-9. Select LLDB as debugger (you might need to set the path to your installtion)
-10. Start debugging with Qt Creator
-
-Creating a release build
-------------------------
-You can ignore this section if you are building `dapscoind` for your own use.
-
-dapscoind/dapscoin-cli binaries are not included in the dapscoin-Qt.app bundle.
-
-If you are building `dapscoind` or `dapscoin-qt` for others, your build machine should be set up
-as follows for maximum compatibility:
-
-All dependencies should be compiled with these flags:
-
- -mmacosx-version-min=10.7
- -arch x86_64
- -isysroot $(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk
-
-Once dependencies are compiled, see release-process.md for how the DAPScoin-Qt.app
-bundle is packaged and signed to create the .dmg disk image that is distributed.
-
-Running
--------
-
-It's now available at `./dapscoind`, provided that you are still in the `src`
-directory. We have to first create the RPC configuration file, though.
-
-Run `./dapscoind` to get the filename where it should be put, or just try these
-commands:
-
-    echo -e "rpcuser=dapscoinrpc\nrpcpassword=$(xxd -l 16 -p /dev/urandom)" > "/Users/${USER}/Library/Application Support/DAPScoin/dapscoin.conf"
-    chmod 600 "/Users/${USER}/Library/Application Support/DAPScoin/dapscoin.conf"
-
-The next time you run it, it will start downloading the blockchain, but it won't
-output anything while it's doing this. This process may take several hours;
-you can monitor its process by looking at the debug.log file, like this:
-
-    tail -f $HOME/Library/Application\ Support/DAPScoin/debug.log
-
-Other commands:
--------
-
-    ./dapscoind -daemon # to start the dapscoin daemon.
-    ./dapscoin-cli --help  # for a list of command-line options.
-    ./dapscoin-cli help    # When the daemon is running, to get a list of RPC commands
+processors only.
+* Building with downloaded Qt binaries is not officially supported. See the notes in [#7714](https://github.com/dapscoin/dapscoin/issues/7714).


### PR DESCRIPTION
> TLDR: This updates our macOS toolchain to use a newer version of Clang, cctools (including new [dependency on libtapi](https://github.com/tpoechtrager/cctools-port/tree/master#dependencies)), LD64 and the macOS SDK.
> 
> I've been testing depends builds (`HOST=x86_64-apple-darwin16`) inside a Debian Buster [Docker container](https://github.com/fanquake/core-review/blob/master/docker/debian.dockerfile), and running the resultant `bitcoind` and `bitcoin-qt` binaries on a macOS `10.14.4` system. The `.dmg` generated by a `make deploy` also mounts correctly on the same macOS system.
> 
> #### Clang
> Upgraded from `3.7.1` to [`6.0.1`](https://releases.llvm.org/6.0.1/docs/ReleaseNotes.html)
> 
> #### cctools
> * cctools `877.8` -> [`921`](https://opensource.apple.com/tarballs/cctools/)
> * LD64 `253.9` -> [`409.12`](https://opensource.apple.com/source/ld64/)
> * TAPI [`1000.10.8`](https://opensource.apple.com/tarballs/tapi/)
> 
> See [tpoechtrager/cctools-port](https://github.com/tpoechtrager/cctools-port/) and [tpoechtrager/apple-libtapi](https://github.com/tpoechtrager/apple-libtapi/).
> 
> #### macOS SDK
> Upgraded from building against the macOS `10.11` SDK to the macOS `10.14` SDK.
> 
> #### TODO
> * [x]  Make the `10.14` SDK available to Travis.
> 
> Fixes: #16052
> Closes: #14797

from https://github.com/bitcoin/bitcoin/pull/16392