### PR TITLE
[Upstream] Improve Fatal LevelDB Log Messages

### DIFF
--- a/src/leveldbwrapper.cpp
+++ b/src/leveldbwrapper.cpp
@@ -17,14 +17,10 @@ void HandleError(const leveldb::Status& status)
 {
     if (status.ok())
         return;
-    LogPrintf("%s\n", status.ToString());
-    if (status.IsCorruption())
-        throw leveldb_error("Database corrupted");
-    if (status.IsIOError())
-        throw leveldb_error("Database I/O error");
-    if (status.IsNotFound())
-        throw leveldb_error("Database entry missing");
-    throw leveldb_error("Unknown database error");
+    const std::string errmsg = "Fatal LevelDB error: " + status.ToString();
+    LogPrintf("%s\n", errmsg);
+    LogPrintf("You can use -debug=leveldb to get more complete diagnostic messages\n");
+    throw leveldb_error(errmsg);
 }
 
 static void SetMaxOpenFiles(leveldb::Options *options) {


### PR DESCRIPTION
> The `leveldb::Status` class logs the filename of corrupted files, which might be useful when looking at error reports from usres. In theory this is already logged via the `LogPrintf()` statement in `HandleError()`, but that may not always be close to where the final error message is logged, e.g. see [#11355 (comment)](https://github.com/bitcoin/bitcoin/issues/11355#issuecomment-340340542) where the log trace provided by the user does not contain that information (and other user comments in the same issue).
> 
> This also adds a log message instructing the user to run the process with `-debug=leveldb`, which provides much more verbose error messages about LevelDB internals. This may not really help much, but improving the error messages here can't hurt.

from https://github.com/bitcoin/bitcoin/pull/12659

This will be helpful for better debugging database/leveldb issues 