### PR TITLE
[Upstream] gui: fix ban from qt console

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -635,6 +635,7 @@ void CNode::AddWhitelistedRange(const CSubNet &subnet) {
 void CNode::copyStats(CNodeStats &stats) {
     stats.nodeid = this->GetId();
     X(nServices);
+    X(addr);
     X(nLastSend);
     X(nLastRecv);
     X(nTimeConnected);

--- a/src/net.h
+++ b/src/net.h
@@ -179,6 +179,7 @@ public:
     double dPingTime;
     double dPingWait;
     std::string addrLocal;
+    CAddress addr;
 };
 
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1003,15 +1003,19 @@ void RPCConsole::banSelectedNode(int bantime)
 {
     if (!clientModel)
         return;
+
+    if(cachedNodeid == -1)
+        return;
+
     // Get currently selected peer address
-    QString strNode = GUIUtil::getEntryData(ui->peerWidget, 0, PeerTableModel::Address);
+    int detailNodeRow = clientModel->getPeerTableModel()->getRowByNodeId(cachedNodeid);
+    if(detailNodeRow < 0)
+        return;
+
     // Find possible nodes, ban it and clear the selected node
-    if (FindNode(strNode.toStdString())) {
-        std::string nStr = strNode.toStdString();
-        std::string addr;
-        int port = 0;
-        SplitHostPort(nStr, port, addr);
-        CNode::Ban(CNetAddr(addr), BanReasonManuallyAdded, bantime);
+    const CNodeCombinedStats *stats = clientModel->getPeerTableModel()->getNodeStats(detailNodeRow);
+    if(stats) {
+        CNode::Ban(stats->nodeStats.addr, BanReasonManuallyAdded, bantime);
         clearSelectedNode();
         clientModel->getBanTableModel()->refresh();
     }


### PR DESCRIPTION
> Rather than doing a circle and re-resolving the node's IP, just use the one from nodestats directly.
> 
> This requires syncing the addr field from CNode.
> 
> Fixes #8876

from https://github.com/bitcoin/bitcoin/pull/8885

This bug was introduced with #151 - here we use a slightly modified version of https://github.com/bitcoin/bitcoin/commit/cb78c60534e5be205f9190cb0cde700f9e9fa38d as we do not have conman)