### PR TITLE
[Upstream] [Wallet] Do not try to resend transactions if the node is importing or in IBD

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6630,7 +6630,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         // Resend wallet transactions that haven't gotten in a block yet
         // Except during reindex, importing and IBD, when old wallet
         // transactions become unconfirmed and spams other nodes.
-        if (!fReindex) {
+        if (!fReindex && !fImporting && !IsInitialBlockDownload()) {
             GetMainSignals().Broadcast();
         }
 


### PR DESCRIPTION
> As the title says, the wallet shouldn't resend transactions if the node is importing or in IBD state. The node doesn't know the real status until it's synced.

from https://github.com/PIVX-Project/PIVX/pull/1783