### PR TITLE
[BUG] fValid fix - If wallet is locked, return false on generateKeyImage

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6753,6 +6753,9 @@ bool CWallet::findCorrespondingPrivateKey(const CTxOut& txout, CKey& key) const
 
 bool CWallet::generateKeyImage(const CScript& scriptPubKey, CKeyImage& img) const
 {
+    if (IsLocked()) {
+        return false;
+    }
     std::set<CKeyID> keyIDs;
     GetKeys(keyIDs);
     CKey key;


### PR DESCRIPTION
Copy of #207 but to `master` for this release