### PR TITLE
Add IsUnsupportedVersion for banned versions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5763,7 +5763,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         }
         if (IsUnsupportedVersion(pfrom->strSubVer)) {
                 // disconnect from peers other than these sub versions
-                LogPrintf("partner %s using obsolete version %s; banning and disconnecting\n", pfrom->addr.ToString().c_str(), pfrom->strSubVer.c_str());
+                LogPrintf("peer %s using unsupported version %s; disconnecting and banning\n", pfrom->addr.ToString().c_str(), pfrom->strSubVer.c_str());
                 state->fShouldBan = true;
                 pfrom->fDisconnect = true;
                 return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5761,7 +5761,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             vRecv >> LIMITED_STRING(pfrom->strSubVer, MAX_SUBVERSION_LENGTH);
             pfrom->cleanSubVer = SanitizeString(pfrom->strSubVer);
         }
-        if (pfrom->strSubVer == "/DAPScoin:0.27.5.1/" || pfrom->strSubVer == "/DAPScoin:1.0.0/" || pfrom->strSubVer == "/DAPScoin:1.0.1/" || pfrom->strSubVer == "/DAPS:1.0.1.3/" || pfrom->strSubVer == "/DAPS:1.0.2/" || pfrom->strSubVer == "/DAPS:1.0.3.4/" || pfrom->strSubVer == "/DAPS:1.0.4.6/" || pfrom->strSubVer == "/DAPS:1.0.5.7/" || pfrom->strSubVer == "/DAPS:1.0.5.8/") {
+        if (IsUnsupportedVersion(pfrom->strSubVer)) {
                 // disconnect from peers other than these sub versions
                 LogPrintf("partner %s using obsolete version %s; banning and disconnecting\n", pfrom->addr.ToString().c_str(), pfrom->strSubVer.c_str());
                 state->fShouldBan = true;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -125,6 +125,10 @@ unsigned short GetListenPort() {
     return (unsigned short) (GetArg("-port", Params().GetDefaultPort()));
 }
 
+bool IsUnsupportedVersion(std::string strSubVer) {
+    return (strSubVer == "/DAPScoin:0.27.5.1/" || strSubVer == "/DAPScoin:1.0.0/" || strSubVer == "/DAPScoin:1.0.1/" || strSubVer == "/DAPS:1.0.1.3/" || strSubVer == "/DAPS:1.0.2/" || strSubVer == "/DAPS:1.0.3.4/" || strSubVer == "/DAPS:1.0.4.6/" || strSubVer == "/DAPS:1.0.5.7/" || strSubVer == "/DAPS:1.0.5.8/");
+}
+
 // find 'best' local address for a particular peer
 bool GetLocal(CService &addr, const CNetAddr *paddrPeer) {
     if (!fListen)

--- a/src/net.h
+++ b/src/net.h
@@ -770,5 +770,6 @@ public:
     bool Read(banmap_t& banSet);
 };
 void DumpBanlist();
+bool IsUnsupportedVersion(std::string strSubVer);
 
 #endif // BITCOIN_NET_H


### PR DESCRIPTION
- Add IsUnsupportedVersion for banned versions
Returns:
- /DAPScoin:0.27.5.1/
- /DAPScoin:1.0.0/
- /DAPScoin:1.0.1/
- /DAPS:1.0.1.3/
- /DAPS:1.0.2/
- /DAPS:1.0.3.4/
- /DAPS:1.0.4.6/
- /DAPS:1.0.5.7/
- /DAPS:1.0.5.8/

Update log text for IsUnsupportedVersion -> better match other wording used in logs and describe actions in proper order
