### PR TITLE
Add check for synced before allowing Staking toggle

### DIFF
--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -11,6 +11,7 @@
 #include "guiutil.h"
 #include "guiconstants.h"
 #include "bitcoingui.h"
+#include "masternode-sync.h"
 #include "optionsmodel.h"
 #include "receiverequestdialog.h"
 #include "recentrequeststablemodel.h"
@@ -420,6 +421,15 @@ bool OptionsPage::matchNewPasswords()
 
 void OptionsPage::on_EnableStaking(ToggleButton* widget)
 {
+    if (!masternodeSync.IsSynced()) {
+        QMessageBox msgBox;
+        msgBox.setWindowTitle("Staking Disabled - Syncing");
+        msgBox.setText("Enable Staking is disabled when you are still syncing the wallet. Please allow the wallet to fully sync before attempting to Enable Staking.");
+        msgBox.setStyleSheet(GUIUtil::loadStyleSheet());
+        msgBox.setIcon(QMessageBox::Warning);
+        msgBox.exec();
+        return;
+    }
     int status = model->getEncryptionStatus();
     if (status == WalletModel::Locked || status == WalletModel::UnlockedForAnonymizationOnly) {
         QMessageBox msgBox;


### PR DESCRIPTION
Since a user is technically not able to successfully stake until the wallet is fully synced, prevent toggling it on by adding a check for synced