### PR TITLE
[Build] Fix PoA warning - re: '&&' within '||'

### DIFF
--- a/src/poa.cpp
+++ b/src/poa.cpp
@@ -248,7 +248,7 @@ bool CheckPoAContainRecentHash(const CBlock& block)
             while(pIndexLoop && !pIndexLoop->IsProofOfStake()) {
                 pIndexLoop = pIndexLoop->pprev;
             }
-            if (!pIndexLoop || pIndexLoop->GetBlockHash() != lastAuditedPoSHash && !IsFixedAudit(fixedPoSAuditedHash.GetHex())) {
+            if (!pIndexLoop || (pIndexLoop->GetBlockHash() != lastAuditedPoSHash && !IsFixedAudit(fixedPoSAuditedHash.GetHex()))) {
                 return error("CheckPoAContainRecentHash(): Some PoS block between %s and %s is not audited\n", lastAuditedPoSHash.GetHex(), currentFirstPoSAuditedHash.GetHex());
             }
 


### PR DESCRIPTION
Fix PoA warning - re: '&&' within '||'

```poa.cpp:251:81: warning: '&&' within '||' [-Wlogical-op-parentheses]
            if (!pIndexLoop || pIndexLoop->GetBlockHash() != lastAuditedPoSHash && !IsFixedAudit(fixedPoSAuditedHash.GetHex())) {
                            ~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
poa.cpp:251:81: note: place parentheses around the '&&' expression to silence this warning
            if (!pIndexLoop || pIndexLoop->GetBlockHash() != lastAuditedPoSHash && !IsFixedAudit(fixedPoSAuditedHash.GetHex())) {
                                                                                ^
                               (                                                                                              )
1 warning generated.```
