### PR TITLE
[Feature] Add fAlwaysRequest2FA to request 2FA before each send

### DIFF
--- a/src/qt/forms/optionspage.ui
+++ b/src/qt/forms/optionspage.ui
@@ -34,7 +34,7 @@
         <x>0</x>
         <y>0</y>
         <width>806</width>
-        <height>565</height>
+        <height>588</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -206,6 +206,13 @@
                </widget>
               </item>
              </layout>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="alwaysRequest2FA">
+              <property name="text">
+               <string>Request authentication code before sending any transactions</string>
+              </property>
+             </widget>
             </item>
             <item>
              <widget class="QLabel" name="label_3">

--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -153,10 +153,12 @@ OptionsPage::OptionsPage(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenu
     ui->mapPortUpnp->setChecked(settings.value("fUseUPnP", false).toBool());
     ui->minimizeToTray->setChecked(settings.value("fMinimizeToTray", false).toBool());
     ui->minimizeOnClose->setChecked(settings.value("fMinimizeOnClose", false).toBool());
+    ui->alwaysRequest2FA->setChecked(settings.value("fAlwaysRequest2FA", false).toBool());
     connect(ui->addNewFunds, SIGNAL(stateChanged(int)), this, SLOT(setAutoConsolidate(int)));
     connect(ui->mapPortUpnp, SIGNAL(stateChanged(int)), this, SLOT(mapPortUpnp_clicked(int)));
     connect(ui->minimizeToTray, SIGNAL(stateChanged(int)), this, SLOT(minimizeToTray_clicked(int)));
     connect(ui->minimizeOnClose, SIGNAL(stateChanged(int)), this, SLOT(minimizeOnClose_clicked(int)));
+    connect(ui->alwaysRequest2FA, SIGNAL(stateChanged(int)), this, SLOT(alwaysRequest2FA_clicked(int)));
 }
 
 void OptionsPage::setStakingToggle()
@@ -986,4 +988,25 @@ void OptionsPage::changeDigits(int digit)
     }
     digit = ui->comboBox->currentText().toInt();
     settings.setValue("2fadigits", digit);
+}
+
+
+void OptionsPage::alwaysRequest2FA_clicked(int state)
+{
+    int status = model->getEncryptionStatus();
+    if (status == WalletModel::Locked || status == WalletModel::UnlockedForAnonymizationOnly) {
+        QMessageBox msgBox;
+        msgBox.setWindowTitle("2FA Settings");
+        msgBox.setIcon(QMessageBox::Information);
+        msgBox.setText("Please unlock the keychain wallet with your passphrase before attempting to change this setting.");
+        msgBox.setStyleSheet(GUIUtil::loadStyleSheet());
+        msgBox.exec();
+        return;
+    }
+    bool twofastatus = pwalletMain->Read2FA();
+    if (twofastatus && ui->alwaysRequest2FA->isChecked()) {
+        settings.setValue("fAlwaysRequest2FA", true);
+    } else {
+        settings.setValue("fAlwaysRequest2FA", false);
+    }
 }

--- a/src/qt/optionspage.h
+++ b/src/qt/optionspage.h
@@ -100,6 +100,7 @@ private Q_SLOTS:
     void minimizeToTray_clicked(int);
     void minimizeOnClose_clicked(int);
     void changeDigits(int);
+    void alwaysRequest2FA_clicked(int);
 };
 
 #endif // BITCOIN_QT_OPTIONSPAGE_H


### PR DESCRIPTION
As requested by a few community members, added a feature to request 2FA code before each transaction send.

Settings screen:
![image](https://user-images.githubusercontent.com/2319897/102735072-7582aa00-430f-11eb-8ee2-9f901dbcd11a.png)

Send Confirmation:
![image](https://user-images.githubusercontent.com/2319897/102735826-67358d80-4311-11eb-91d7-54e1d2193ce1.png)

2FA Request:
![image](https://user-images.githubusercontent.com/2319897/102735931-a6fc7500-4311-11eb-9741-45ab73425a0e.png)
