### PR TITLE
[Fix] Add sync fix for block 803585

### DIFF
--- a/src/poa.cpp
+++ b/src/poa.cpp
@@ -216,7 +216,7 @@ bool CheckPoAContainRecentHash(const CBlock& block)
     } else {
         if (pindex->nHeight >= Params().START_POA_BLOCK()) {
             // Bypass bad block
-            if (pindex->nHeight == 719390) {
+            if (pindex->nHeight == 719390 || pindex->nHeight == 719456) {
                 return true;
             }
             CBlock prevPoablock;


### PR DESCRIPTION
CheckPoAContainRecentHash checks previous PoA block, so we use 719456 here